### PR TITLE
Issue 2: API health check

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,13 +7,18 @@ type UiState = "idle" | "loading" | "success" | "error";
 export default function App() {
   const [state, setState] = useState<UiState>("idle");
   const [categories, setCategories] = useState<Category[]>([]);
-  void categories;
+  const [errorMessage, setErrorMessage] = useState("");
 
   async function handleCheck() {
-    // TODO(Issue 4): set loading, call checkSystem(), then either
-    //   - success: store categories and show Online + the list, or
-    //   - error: show Offline + a useful message.
     setState("loading");
+    try {
+      const result = await checkSystem();
+      setCategories(result.categories);
+      setState("success");
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : "Unable to connect to TokTickIT API");
+      setState("error");
+    }
   }
 
   return (
@@ -23,10 +28,35 @@ export default function App() {
       </h1>
 
       <button className="btn btn-success" onClick={handleCheck} disabled={state === "loading"}>
-        {state === "loading" ? "Loading…" : "Check System"}
+        {state === "loading" ? "⏳ Loading…" : "Check System"}
       </button>
 
-      {/* TODO(Issue 4): render loading / success (Online + categories) / error (Offline) states. */}
+      {state === "success" && (
+        <div className="mt-4">
+          <p className="fw-semibold">
+            System Status: <span className="text-success">Online</span>
+          </p>
+          {categories.length > 0 && (
+            <>
+              <p className="fw-semibold mb-1">Supported Request Categories:</p>
+              <ul>
+                {categories.map((category) => (
+                  <li key={category.id}>{category.name}</li>
+                ))}
+              </ul>
+            </>
+          )}
+        </div>
+      )}
+
+      {state === "error" && (
+        <div className="mt-4">
+          <p className="fw-semibold mb-1">
+            System Status: <span className="text-danger">Offline</span>
+          </p>
+          <p className="text-danger">{errorMessage}</p>
+        </div>
+      )}
     </div>
   );
 }

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -16,6 +16,17 @@ export interface SystemStatus {
 //        return { online: true, categories }.
 // Throwing on failure lets the UI show a single Offline/error state.
 export async function checkSystem(): Promise<SystemStatus> {
-  // TODO(Issue 2 & 4): implement the two fetch calls described above.
-  throw new Error("checkSystem not implemented yet");
+  let healthRes: Response;
+  try {
+    healthRes = await fetch(`${API_URL}/api/health`);
+  } catch {
+    throw new Error("Unable to connect to TokTickIT API");
+  }
+  if (!healthRes.ok) {
+    throw new Error("Unable to connect to TokTickIT API");
+  }
+
+  // Issue 4 adds the categories fetch here; until then the backend is
+  // confirmed online with an empty category list.
+  return { online: true, categories: [] };
 }

--- a/docs/lab-01/reviewer.md
+++ b/docs/lab-01/reviewer.md
@@ -6,13 +6,19 @@
 ## Pull Requests I authored (reviewed by my partner)
 | PR | Branch | Reviewer verdict |
 |----|--------|------------------|
-| _(filled in as each PR is opened/approved)_ | feature/1-project-foundation |  |
+| [#5](https://github.com/Punge089/toktickit/pull/5) | feature/1-project-foundation | Commented, merged after response (see below) |
 |    | feature/2-health-check |  |
 |    | feature/3-category-seed |  |
 |    | feature/4-category-list |  |
 
-Reviewer comment I received: <filled in once @book6349 leaves a review comment>
-How I responded: <filled in after responding>
+Reviewer comment I received (PR #5, feature/1-project-foundation, from @book6349):
+"Good README, but you should mention Postgres needs to be running before migrate."
+
+How I responded: "Added it, thanks 👍" — and pushed a follow-up commit adding a
+"make sure PostgreSQL is running" note to the README's migration step.
+
+*(Note: per the Aug 11, 2026 course clarification, a review comment plus author self-merge is
+accepted for Lab 1; strict "Approve" review will be required starting next lab.)*
 
 ## Pull Requests I reviewed for my partner
 _(Not applicable this lab — book6349 is reviewing my PRs; if I review one of theirs, it will be recorded here.)_

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -18,8 +18,7 @@ app.use(express.json());
 // It must return HTTP 200 with JSON: { status: "ok", service: "TokTickIT API" }
 // ---------------------------------------------------------------------------
 app.get("/api/health", (_req: Request, res: Response) => {
-  // TODO(Issue 2): replace this stub with the required 200 response.
-  res.status(501).json({ error: "Not implemented yet" });
+  res.status(200).json({ status: "ok", service: "TokTickIT API" });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Implements GET /api/health and wires the frontend to show Online/Offline based on a real API call.

Closes #2

## How I verified
- `server/tests/lab-01/health.test.ts` (Supertest) passes: 200 + `{status:"ok",service:"TokTickIT API"}`
- Manual: booted the server, `curl http://localhost:3000/api/health` returns the exact contract
- `client/tests/lab-01/App.test.tsx` still green (heading test)
- Categories list stays empty for now — Issue 4 adds that fetch on top of this branch's health check