### PR TITLE
docs: finalize reviewer.md

### DIFF
--- a/docs/lab-01/reviewer.md
+++ b/docs/lab-01/reviewer.md
@@ -9,7 +9,7 @@
 | [#5](https://github.com/Punge089/toktickit/pull/5) | feature/1-project-foundation | Commented, merged after response |
 | [#6](https://github.com/Punge089/toktickit/pull/6) | feature/2-health-check | Commented, merged after response |
 | [#7](https://github.com/Punge089/toktickit/pull/7) | feature/3-category-seed | Commented, merged after response |
-| _(pending)_ | feature/4-category-list |  |
+| [#8](https://github.com/Punge089/toktickit/pull/8) | feature/4-category-list | Commented, merged after response |
 
 *(Note: per the Aug 11, 2026 course clarification, a review comment plus author self-merge is
 accepted for Lab 1; strict "Approve" review will be required starting next lab.)*
@@ -31,7 +31,17 @@ same every time? Just thinking about Issue 4 needing to list them."
 **Me:** "Yeah, id is auto-increment so it won't change. But I'll still add orderBy: id explicitly
 in Issue 4 just to be safe, thank you for asking."
 
+### PR #8 — Category List
+**@book6349:** "Checked it out, clicked Check System and it showed all 4 categories correctly.
+Also tried killing the server and it fell back to Offline properly. One thing I noticed, the
+categories endpoint returns a 500 on failure, does the frontend show a useful message for that
+case too or just for a totally dead server?"
+**Me:** "Good catch, yeah it's the same 'Unable to connect' message for both a dead server and a
+500 from categories, since checkSystem throws either way and the UI only has one error state.
+Keeps it simple for this lab, thank you!"
+
 ## Pull Requests I reviewed for my partner
-_(Not applicable this lab — book6349 is reviewing my PRs; if I review one of theirs, it will be recorded here.)_
+_(To be filled in: I need to review one of @book6349's PRs on their own individual-sprint repo
+and record my comment + their response here, per the Part 1 bidirectional review requirement.)_
 My comment: <...>
 Partner's response: <...>


### PR DESCRIPTION
Small documentation-only follow-up per the Aug 11 clarification (feature/Lab1Doc is allowed for post-Issue-4 doc updates). Records the PR #8 review exchange in docs/lab-01/reviewer.md.