### PR TITLE
Lab 1 release: final report links

### DIFF
--- a/report_lab01_67070503420.md
+++ b/report_lab01_67070503420.md
@@ -21,6 +21,8 @@
 | PR #8 — feature/4-category-list → lab1-staging | https://github.com/Punge089/toktickit/pull/8 |
 | PR #9 — docs fix → lab1-staging | https://github.com/Punge089/toktickit/pull/9 |
 | PR #10 — Release: lab1-staging → main | https://github.com/Punge089/toktickit/pull/10 |
+| PR #11 — docs (screenshots + report) → lab1-staging | https://github.com/Punge089/toktickit/pull/11 |
+| PR #12 — Release: lab1-staging → main | https://github.com/Punge089/toktickit/pull/12 |
 
 ## GitHub Project — Kanban board
 


### PR DESCRIPTION
Final tiny release bringing PR #11/#12 links into the submission report on main.