### PR TITLE
Lab 1 release: reviewer name/ID fix

### DIFF
--- a/docs/lab-01/reviewer.md
+++ b/docs/lab-01/reviewer.md
@@ -1,7 +1,7 @@
 # Lab 1 - Peer Review Record
 
 **Author:** Bannasorn Thongkorn - 67070503420 - GitHub: @Punge089
-**Peer reviewer:** book6349 - GitHub: @book6349
+**Peer reviewer:** Papangkorn Jitvoottikrai - 67070503421 - GitHub: @book6349
 
 ## Pull Requests I authored (reviewed by my partner)
 | PR | Branch | Reviewer verdict |

--- a/report_lab01_67070503420.md
+++ b/report_lab01_67070503420.md
@@ -110,7 +110,7 @@ server/prisma/*.db
 Rendered [docs/lab-01/reviewer.md](docs/lab-01/reviewer.md):
 
 > **Author:** Bannasorn Thongkorn - 67070503420 - GitHub: @Punge089
-> **Peer reviewer:** book6349 - GitHub: @book6349
+> **Peer reviewer:** Papangkorn Jitvoottikrai - 67070503421 - GitHub: @book6349
 
 All four feature PRs (#5–#8) received a real review comment from @book6349 and a direct reply
 from me before I merged them, per the Aug 11, 2026 course clarification allowing comment +


### PR DESCRIPTION
Brings the peer reviewer full name/ID fix into main.