### PR TITLE
Issue 22: Lab 2 data model, migration, and idempotent seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,31 @@ toktickit/
 
 ## Testing
 
+Server tests run against a **dedicated test database**, never the dev database in `server/.env`, so
+seed/CRUD tests never touch your local dev data. Create it once and point `server/.env.test` at it
+(`server/.env.test` is gitignored, same as `.env`):
+
 ```bash
-# API tests (Supertest) - from server/
+psql -U postgres -c "CREATE DATABASE toktickit_test;"
+```
+```
+# server/.env.test
+DATABASE_URL="postgresql://toktickit:toktickit@localhost:5432/toktickit_test?schema=public"
+PORT=3001
+```
+```bash
+cd server
+DATABASE_URL="postgresql://toktickit:toktickit@localhost:5432/toktickit_test?schema=public" npx prisma migrate deploy
+DATABASE_URL="postgresql://toktickit:toktickit@localhost:5432/toktickit_test?schema=public" npx tsx prisma/seed.ts
+```
+
+Then run the suites:
+
+```bash
+# unit + API tests (Vitest + Supertest) - from server/, uses server/.env.test automatically
 cd server && npm test
 
-# Frontend tests (Vitest) - from client/
+# frontend unit + UI component tests (Vitest) - from client/
 cd client && npm test
 ```
 

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -21,6 +21,7 @@ Criterion in `specification.md` §9 maps to at least one row below.
 | UNIT-03 | Unit | BR-20 | File-type allowlist checker | Accepts jpg/jpeg/png/webp/pdf; rejects gif/exe/txt | `server/tests/lab-02/attachment-rules.unit.test.ts` | Planned |
 | UNIT-04 | Unit | BR-21 | File-size boundary checker | Exactly 5MB passes; 5MB+1byte rejected | `server/tests/lab-02/attachment-rules.unit.test.ts` | Planned |
 | UNIT-05 | Unit | BR-25 | Stored-filename generator | Output is a UUID + validated extension, never contains the original filename | `server/tests/lab-02/attachment-rules.unit.test.ts` | Planned |
+| UNIT-06 | Unit | Issue #22 AC | Seed idempotency: run `seedAll()` twice against the test DB | Second run changes no row counts; 4 categories, ≥6 related systems, ≥4 active + ≥1 inactive Requester all present | `server/tests/lab-02/seed.unit.test.ts` | **Pass** |
 | API-01 | API | AC-01 | `POST /api/tickets` valid payload | `201`; response has `ticketNumber`; row exists in DB with `currentStatus=NEW` | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
 | API-02 | API | AC-04, BR-14–17 | `POST /api/tickets` missing `summary` | `400`; `fieldErrors.summary` present; no row created | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
 | API-03 | API | BR-14 | `summary` at 4 and 121 chars (boundary) | Both `400`; 5 and 120 chars both `201` | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |

--- a/server/prisma/migrations/20260824140910_lab2_ticketing/migration.sql
+++ b/server/prisma/migrations/20260824140910_lab2_ticketing/migration.sql
@@ -1,0 +1,112 @@
+-- CreateEnum
+CREATE TYPE "Priority" AS ENUM ('LOW', 'MEDIUM', 'HIGH', 'URGENT');
+
+-- CreateEnum
+CREATE TYPE "TicketStatus" AS ENUM ('NEW');
+
+-- AlterTable
+ALTER TABLE "Category" ADD COLUMN     "isActive" BOOLEAN NOT NULL DEFAULT true;
+
+-- CreateTable
+CREATE TABLE "RequesterUser" (
+    "id" SERIAL NOT NULL,
+    "fullName" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "department" TEXT,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RequesterUser_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RelatedSystem" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RelatedSystem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Ticket" (
+    "id" SERIAL NOT NULL,
+    "ticketNumber" TEXT NOT NULL,
+    "requesterId" INTEGER NOT NULL,
+    "categoryId" INTEGER NOT NULL,
+    "relatedSystemId" INTEGER NOT NULL,
+    "summary" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "requestedPriority" "Priority" NOT NULL,
+    "itPriority" "Priority",
+    "currentStatus" "TicketStatus" NOT NULL DEFAULT 'NEW',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Ticket_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Attachment" (
+    "id" SERIAL NOT NULL,
+    "ticketId" INTEGER NOT NULL,
+    "originalFilename" TEXT NOT NULL,
+    "storedFilename" TEXT NOT NULL,
+    "mimeType" TEXT NOT NULL,
+    "sizeBytes" INTEGER NOT NULL,
+    "uploadedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "uploadedById" INTEGER NOT NULL,
+    "removedAt" TIMESTAMP(3),
+    "removedById" INTEGER,
+    "removalReason" TEXT,
+
+    CONSTRAINT "Attachment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TicketCounter" (
+    "year" INTEGER NOT NULL,
+    "lastValue" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "TicketCounter_pkey" PRIMARY KEY ("year")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RequesterUser_email_key" ON "RequesterUser"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RelatedSystem_name_key" ON "RelatedSystem"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Ticket_ticketNumber_key" ON "Ticket"("ticketNumber");
+
+-- CreateIndex
+CREATE INDEX "Ticket_requesterId_createdAt_idx" ON "Ticket"("requesterId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "Ticket_requesterId_currentStatus_idx" ON "Ticket"("requesterId", "currentStatus");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Attachment_storedFilename_key" ON "Attachment"("storedFilename");
+
+-- CreateIndex
+CREATE INDEX "Attachment_ticketId_removedAt_idx" ON "Attachment"("ticketId", "removedAt");
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_requesterId_fkey" FOREIGN KEY ("requesterId") REFERENCES "RequesterUser"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Category"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_relatedSystemId_fkey" FOREIGN KEY ("relatedSystemId") REFERENCES "RelatedSystem"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Attachment" ADD CONSTRAINT "Attachment_ticketId_fkey" FOREIGN KEY ("ticketId") REFERENCES "Ticket"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Attachment" ADD CONSTRAINT "Attachment_uploadedById_fkey" FOREIGN KEY ("uploadedById") REFERENCES "RequesterUser"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Attachment" ADD CONSTRAINT "Attachment_removedById_fkey" FOREIGN KEY ("removedById") REFERENCES "RequesterUser"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -11,10 +11,107 @@ datasource db {
 }
 
 // ---------------------------------------------------------------------------
-// Issue 3 — Create and seed IT request categories
+// Lab 1 — Issue 3: Create and seed IT request categories
+// Lab 2 — Issue 22: gains isActive + the Ticket relation
 // ---------------------------------------------------------------------------
 model Category {
   id        Int      @id @default(autoincrement())
   name      String   @unique
+  isActive  Boolean  @default(true)
   createdAt DateTime @default(now())
+
+  tickets Ticket[]
+}
+
+// ---------------------------------------------------------------------------
+// Lab 2 — Issue 22: reference tables, Development Requester identity, and the
+// Ticket/Attachment models. See docs/lab-02/specification.md §7 for rationale.
+// ---------------------------------------------------------------------------
+enum Priority {
+  LOW
+  MEDIUM
+  HIGH
+  URGENT
+}
+
+enum TicketStatus {
+  NEW
+}
+
+model RequesterUser {
+  id         Int      @id @default(autoincrement())
+  fullName   String
+  email      String   @unique
+  department String?
+  isActive   Boolean  @default(true)
+  createdAt  DateTime @default(now())
+
+  tickets             Ticket[]
+  uploadedAttachments Attachment[] @relation("AttachmentUploadedBy")
+  removedAttachments  Attachment[] @relation("AttachmentRemovedBy")
+}
+
+model RelatedSystem {
+  id        Int      @id @default(autoincrement())
+  name      String   @unique
+  isActive  Boolean  @default(true)
+  createdAt DateTime @default(now())
+
+  tickets Ticket[]
+}
+
+model Ticket {
+  id                Int           @id @default(autoincrement())
+  ticketNumber      String        @unique
+  requesterId       Int
+  requester         RequesterUser @relation(fields: [requesterId], references: [id])
+  categoryId        Int
+  category          Category      @relation(fields: [categoryId], references: [id])
+  relatedSystemId   Int
+  relatedSystem     RelatedSystem @relation(fields: [relatedSystemId], references: [id])
+  summary           String
+  description       String
+  requestedPriority Priority
+  itPriority        Priority?
+  currentStatus     TicketStatus  @default(NEW)
+  createdAt         DateTime      @default(now())
+  updatedAt         DateTime      @updatedAt
+
+  attachments Attachment[]
+
+  // My Tickets defaults to sorting by createdAt within one Requester's own
+  // tickets (BR-12); status filtering is the other common access pattern.
+  @@index([requesterId, createdAt])
+  @@index([requesterId, currentStatus])
+}
+
+model Attachment {
+  id               Int      @id @default(autoincrement())
+  ticketId         Int
+  ticket           Ticket   @relation(fields: [ticketId], references: [id])
+  originalFilename String
+  storedFilename   String   @unique
+  mimeType         String
+  sizeBytes        Int
+  uploadedAt       DateTime @default(now())
+  uploadedById     Int
+  uploadedBy       RequesterUser @relation("AttachmentUploadedBy", fields: [uploadedById], references: [id])
+
+  // Soft removal (BR-22): removedAt doubles as the "is it removed" flag and
+  // the audit timestamp, so an index on [ticketId, removedAt] serves both the
+  // 5-active-attachment check and the active/removed split display.
+  removedAt     DateTime?
+  removedById   Int?
+  removedBy     RequesterUser? @relation("AttachmentRemovedBy", fields: [removedById], references: [id])
+  removalReason String?
+
+  @@index([ticketId, removedAt])
+}
+
+// One row per year; source of the sequential part of the Ticket Number
+// (BR-01), updated inside the same transaction that inserts the Ticket so
+// concurrent creations cannot collide.
+model TicketCounter {
+  year      Int @id
+  lastValue Int @default(0)
 }

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -1,28 +1,91 @@
 import { getPrisma } from "../src/prisma.js";
 
-// Issue 3 — seed the four supported categories.
-// The four names are: Account and Access, Hardware, Software, Network.
-// Requirement: running the seed twice must NOT create duplicates.
-// Hint: prisma.category.upsert({ where:{name}, update:{}, create:{name} }).
+// Lab 1 — Issue 3: the four supported categories.
 const CATEGORY_NAMES = ["Account and Access", "Hardware", "Software", "Network"];
 
-async function main() {
+// Lab 2 — Issue 22: related systems, and Development Requesters.
+// Requirement: running the seed twice must NOT create duplicates (BR — see
+// specification.md §5.3). Every insert below is an upsert keyed on a unique
+// column for exactly that reason.
+const RELATED_SYSTEM_NAMES = [
+  "Email",
+  "Campus Wi-Fi",
+  "VPN",
+  "LEB2 App",
+  "Grade Submission App",
+  "Printer",
+  "Corporate Laptop",
+];
+
+const ACTIVE_REQUESTERS = [
+  { fullName: "Aran Suksawat", email: "aran.suksawat@example.dev", department: "Registrar" },
+  { fullName: "Buppha Ratanakorn", email: "buppha.ratanakorn@example.dev", department: "Finance" },
+  { fullName: "Chai Wongsawat", email: "chai.wongsawat@example.dev", department: "IT Services" },
+  { fullName: "Duangjai Phromma", email: "duangjai.phromma@example.dev", department: "Library" },
+];
+
+const INACTIVE_REQUESTERS = [
+  { fullName: "Somsak Jantawong", email: "somsak.jantawong@example.dev", department: "Alumni Relations" },
+];
+
+export async function seedCategories() {
   const prisma = getPrisma();
   for (const name of CATEGORY_NAMES) {
-    await prisma.category.upsert({
-      where: { name },
-      update: {},
-      create: { name },
-    });
+    await prisma.category.upsert({ where: { name }, update: {}, create: { name } });
   }
-  console.log(`Seeded ${CATEGORY_NAMES.length} categories (idempotent).`);
+  return CATEGORY_NAMES.length;
 }
 
-main()
-  .catch((e) => {
-    console.error(e);
-    process.exit(1);
-  })
-  .finally(async () => {
-    await getPrisma().$disconnect();
-  });
+export async function seedRelatedSystems() {
+  const prisma = getPrisma();
+  for (const name of RELATED_SYSTEM_NAMES) {
+    await prisma.relatedSystem.upsert({ where: { name }, update: {}, create: { name } });
+  }
+  return RELATED_SYSTEM_NAMES.length;
+}
+
+export async function seedRequesters() {
+  const prisma = getPrisma();
+  for (const r of ACTIVE_REQUESTERS) {
+    await prisma.requesterUser.upsert({
+      where: { email: r.email },
+      update: {},
+      create: { ...r, isActive: true },
+    });
+  }
+  for (const r of INACTIVE_REQUESTERS) {
+    await prisma.requesterUser.upsert({
+      where: { email: r.email },
+      update: {},
+      create: { ...r, isActive: false },
+    });
+  }
+  return ACTIVE_REQUESTERS.length + INACTIVE_REQUESTERS.length;
+}
+
+export async function seedAll() {
+  const categories = await seedCategories();
+  const relatedSystems = await seedRelatedSystems();
+  const requesters = await seedRequesters();
+  return { categories, relatedSystems, requesters };
+}
+
+async function main() {
+  const { categories, relatedSystems, requesters } = await seedAll();
+  console.log(
+    `Seeded (idempotent): ${categories} categories, ${relatedSystems} related systems, ${requesters} Development Requesters.`,
+  );
+}
+
+// Only run main() when this file is executed directly (tsx prisma/seed.ts),
+// not when its functions are imported by a test.
+if (process.argv[1] && process.argv[1].endsWith("seed.ts")) {
+  main()
+    .catch((e) => {
+      console.error(e);
+      process.exit(1);
+    })
+    .finally(async () => {
+      await getPrisma().$disconnect();
+    });
+}

--- a/server/tests/lab-02/seed.unit.test.ts
+++ b/server/tests/lab-02/seed.unit.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { getPrisma } from "../../src/prisma.js";
+import { seedAll } from "../../prisma/seed.js";
+
+// Issue 22 acceptance criterion: "Seed is idempotent (running it twice
+// creates no duplicates)." Runs the real seed functions twice against the
+// test database (server/.env.test — see tests/setup.ts) and asserts the
+// second run adds nothing.
+describe("Lab 2 seed idempotency", () => {
+  it("running seedAll() twice does not change row counts", async () => {
+    const prisma = getPrisma();
+
+    await seedAll();
+    const [categoriesAfterFirst, systemsAfterFirst, requestersAfterFirst] = await Promise.all([
+      prisma.category.count(),
+      prisma.relatedSystem.count(),
+      prisma.requesterUser.count(),
+    ]);
+
+    await seedAll();
+    const [categoriesAfterSecond, systemsAfterSecond, requestersAfterSecond] = await Promise.all([
+      prisma.category.count(),
+      prisma.relatedSystem.count(),
+      prisma.requesterUser.count(),
+    ]);
+
+    expect(categoriesAfterSecond).toBe(categoriesAfterFirst);
+    expect(systemsAfterSecond).toBe(systemsAfterFirst);
+    expect(requestersAfterSecond).toBe(requestersAfterFirst);
+  });
+
+  it("seeds the four required categories", async () => {
+    const prisma = getPrisma();
+    await seedAll();
+    const names = (await prisma.category.findMany({ select: { name: true } })).map((c) => c.name);
+    for (const required of ["Account and Access", "Hardware", "Software", "Network"]) {
+      expect(names).toContain(required);
+    }
+  });
+
+  it("seeds at least six related systems", async () => {
+    const prisma = getPrisma();
+    await seedAll();
+    const count = await prisma.relatedSystem.count();
+    expect(count).toBeGreaterThanOrEqual(6);
+  });
+
+  it("seeds at least four active and one inactive Development Requester", async () => {
+    const prisma = getPrisma();
+    await seedAll();
+    const active = await prisma.requesterUser.count({ where: { isActive: true } });
+    const inactive = await prisma.requesterUser.count({ where: { isActive: false } });
+    expect(active).toBeGreaterThanOrEqual(4);
+    expect(inactive).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/server/tests/setup.ts
+++ b/server/tests/setup.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+// Lab 2 — Issue 22: point every test run at server/.env.test instead of the
+// dev database in server/.env, so seed/CRUD tests never touch dev data.
+// Runs before any test file, and before getPrisma() is ever called (the
+// Prisma client is a lazy singleton — see src/prisma.ts), so this always
+// wins over whatever @prisma/client would otherwise auto-load.
+const envTestPath = path.resolve(process.cwd(), ".env.test");
+
+let content: string;
+try {
+  content = readFileSync(envTestPath, "utf-8");
+} catch {
+  throw new Error(
+    `server/.env.test not found. Copy server/.env and point DATABASE_URL at a ` +
+      `dedicated test database (see docs/lab-02/specification.md Phase 0 setup).`,
+  );
+}
+
+for (const rawLine of content.split("\n")) {
+  const line = rawLine.trim();
+  if (!line || line.startsWith("#")) continue;
+  const eq = line.indexOf("=");
+  if (eq === -1) continue;
+  const key = line.slice(0, eq).trim();
+  let value = line.slice(eq + 1).trim();
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    value = value.slice(1, -1);
+  }
+  process.env[key] = value;
+}

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -4,5 +4,6 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["tests/**/*.test.ts"],
+    setupFiles: ["./tests/setup.ts"],
   },
 });


### PR DESCRIPTION
## Summary
Adds RequesterUser, RelatedSystem, Ticket, Attachment, and TicketCounter to the Prisma schema per `specification.md` §7, plus `isActive` on Category. Migration applied to both dev and test databases.

## Details
- Idempotent seed: 4 categories, 7 related systems, 4 active + 1 inactive Development Requester
- `server/tests/setup.ts` now points the whole server test suite at `server/.env.test` instead of the dev DB
- `server/tests/lab-02/seed.unit.test.ts`: idempotency + minimum-count coverage (UNIT-06)
- README documents the new test-database setup step

## Test evidence
`cd server && npm test` — 3 files, 6 tests, all passing (2 Lab 1 + 4 Lab 2) against `toktickit_test`.

Resolves #22

Note: this PR targets `lab2-staging`, not the default branch, so the keyword above shows as a mention only. Link it to Issue 22 manually via the Development panel (gear icon) per the TokTickIT GitHub Workflow Guide.