### PR TITLE
Issue 23: Zen Green theme, reusable components, and app shell

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "bootstrap": "^5.3.3",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.30.6"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.3",
@@ -981,6 +982,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.4.tgz",
+      "integrity": "sha512-q7j5geK7xs3UJSdm9/iytUNclBnLmYx1EnSeCFXHPeutdqgIMeFeHtUZgS3EhlKxdBEAu8OwtJCwmLrEzpSs7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2749,6 +2759,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.6",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.6.tgz",
+      "integrity": "sha512-5HfK7k5im7LTOB0EqCQmfvy4C13G92Ssj1VTmouTK3AJvyjKTnFuCV0vcMAD/JS+JC4DvDIBRrlAeJIFjh5VWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.6",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.6.tgz",
+      "integrity": "sha512-0RHKZz7wwffvkU+2MFVT2NnjK44ssLEV+m0CAJaS2Ksmorrwj7WxH00jO0SOCW26/tINUnJHToXblDs33I38YQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.4",
+        "react-router": "6.30.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/redent": {

--- a/client/package.json
+++ b/client/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "bootstrap": "^5.3.3",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.30.6"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",

--- a/client/src/AppRouter.tsx
+++ b/client/src/AppRouter.tsx
@@ -1,0 +1,23 @@
+import { Navigate, Route, Routes } from "react-router-dom";
+import { AppShell } from "./components/shell/AppShell.js";
+import { RequesterSelectPage } from "./pages/RequesterSelectPage.js";
+import { CreateTicketPage } from "./pages/CreateTicketPage.js";
+import { MyTicketsPage } from "./pages/MyTicketsPage.js";
+import { TicketDetailPage } from "./pages/TicketDetailPage.js";
+
+// Issue 23 — router skeleton for the 4 Lab 2 screens. The route guard that
+// redirects to /select-requester when no Development Requester is selected
+// (AC-02) is wired in Issue 25 once the real Requester context exists.
+export function AppRouter() {
+  return (
+    <AppShell>
+      <Routes>
+        <Route path="/" element={<Navigate to="/select-requester" replace />} />
+        <Route path="/select-requester" element={<RequesterSelectPage />} />
+        <Route path="/tickets/new" element={<CreateTicketPage />} />
+        <Route path="/tickets" element={<MyTicketsPage />} />
+        <Route path="/tickets/:id" element={<TicketDetailPage />} />
+      </Routes>
+    </AppShell>
+  );
+}

--- a/client/src/components/shell/AppShell.tsx
+++ b/client/src/components/shell/AppShell.tsx
@@ -1,0 +1,73 @@
+import { ReactNode, useState } from "react";
+import { NavLink } from "react-router-dom";
+
+interface AppShellProps {
+  children: ReactNode;
+  /** Placeholder until Issue 25 wires the real Requester context. */
+  requesterName?: string | null;
+  onChangeRequester?: () => void;
+}
+
+const NAV_LINK_CLASS = ({ isActive }: { isActive: boolean }) =>
+  ["zen-shell-nav-link", isActive ? "zen-shell-nav-link-active" : ""].filter(Boolean).join(" ");
+
+// Issue 23 — application shell (ui-spec.md §4): TokTickIT identity, My
+// Tickets / Create Ticket nav with active-page indication, current-Requester
+// display + Change Requester action, and a mobile nav that collapses below
+// 768px.
+export function AppShell({ children, requesterName, onChangeRequester }: AppShellProps) {
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
+
+  return (
+    <div>
+      <header className="zen-shell-header">
+        <a href="/" className="zen-shell-wordmark">
+          TokTickIT
+        </a>
+
+        <button
+          type="button"
+          className="zen-shell-hamburger zen-btn zen-btn-tertiary"
+          aria-label={mobileNavOpen ? "Close navigation menu" : "Open navigation menu"}
+          title={mobileNavOpen ? "Close navigation menu" : "Open navigation menu"}
+          aria-expanded={mobileNavOpen}
+          onClick={() => setMobileNavOpen((open) => !open)}
+        >
+          ☰
+        </button>
+
+        <nav
+          className={["zen-shell-nav", mobileNavOpen ? "zen-shell-nav-open" : ""].filter(Boolean).join(" ")}
+          aria-label="Primary"
+        >
+          <NavLink to="/tickets" className={NAV_LINK_CLASS}>
+            My Tickets
+          </NavLink>
+          <NavLink to="/tickets/new" className={NAV_LINK_CLASS}>
+            Create Ticket
+          </NavLink>
+        </nav>
+
+        <div className="zen-shell-requester">
+          {requesterName ? (
+            <>
+              <span>{requesterName}</span>
+              <button
+                type="button"
+                className="zen-btn zen-btn-tertiary"
+                style={{ color: "#ffffff", minHeight: "auto", padding: 0 }}
+                onClick={onChangeRequester}
+              >
+                Change Requester
+              </button>
+            </>
+          ) : (
+            <span>No Development Requester selected</span>
+          )}
+        </div>
+      </header>
+
+      <main className="zen-shell-main">{children}</main>
+    </div>
+  );
+}

--- a/client/src/components/ui/Alert.tsx
+++ b/client/src/components/ui/Alert.tsx
@@ -1,0 +1,25 @@
+import { ReactNode } from "react";
+
+export type AlertTone = "error" | "warning" | "success";
+
+interface AlertProps {
+  tone: AlertTone;
+  children: ReactNode;
+}
+
+const ICON: Record<AlertTone, string> = {
+  error: "⚠",
+  warning: "▲",
+  success: "✓",
+};
+
+// ui-spec.md §1 — every error/warning/success state carries an icon and
+// text, never color alone.
+export function Alert({ tone, children }: AlertProps) {
+  return (
+    <div className={`zen-alert zen-alert-${tone}`} role={tone === "error" ? "alert" : "status"}>
+      <span aria-hidden="true">{ICON[tone]}</span>
+      <div>{children}</div>
+    </div>
+  );
+}

--- a/client/src/components/ui/Badge.tsx
+++ b/client/src/components/ui/Badge.tsx
@@ -1,0 +1,33 @@
+import { ReactNode } from "react";
+
+export type BadgeTone = "neutral" | "warning" | "error" | "secondary" | "success";
+
+interface BadgeProps {
+  tone: BadgeTone;
+  children: ReactNode;
+}
+
+// ui-spec.md §3 — badges pair color with text; color is never the only
+// signal (AC-18).
+export function Badge({ tone, children }: BadgeProps) {
+  return <span className={`zen-badge zen-badge-${tone}`}>{children}</span>;
+}
+
+const PRIORITY_TONE: Record<string, BadgeTone> = {
+  LOW: "neutral",
+  MEDIUM: "warning",
+  HIGH: "error",
+  URGENT: "error",
+};
+
+export function PriorityBadge({ priority }: { priority: "LOW" | "MEDIUM" | "HIGH" | "URGENT" }) {
+  return <Badge tone={PRIORITY_TONE[priority]}>{priority}</Badge>;
+}
+
+export function StatusBadge({ status }: { status: "NEW" }) {
+  return <Badge tone="secondary">{status}</Badge>;
+}
+
+export function AttachmentStateBadge({ removed }: { removed: boolean }) {
+  return <Badge tone={removed ? "neutral" : "success"}>{removed ? "Removed" : "Active"}</Badge>;
+}

--- a/client/src/components/ui/Button.tsx
+++ b/client/src/components/ui/Button.tsx
@@ -1,0 +1,34 @@
+import { ButtonHTMLAttributes, forwardRef } from "react";
+
+// Issue 23 — Zen Green button hierarchy (ui-spec.md §3).
+// Busy state replaces the label with a spinner + text and disables the
+// button, so a Requester cannot double-submit while a request is in flight.
+export type ButtonVariant = "primary" | "secondary" | "tertiary" | "destructive";
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  busy?: boolean;
+  busyText?: string;
+}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  { variant = "primary", busy = false, busyText = "Working…", disabled, className = "", children, ...rest },
+  ref,
+) {
+  const classes = ["zen-btn", `zen-btn-${variant}`, busy ? "zen-btn-busy" : "", className]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <button ref={ref} type="button" className={classes} disabled={disabled || busy} {...rest}>
+      {busy ? (
+        <>
+          <span className="zen-spinner" aria-hidden="true" />
+          {busyText}
+        </>
+      ) : (
+        children
+      )}
+    </button>
+  );
+});

--- a/client/src/components/ui/EmptyState.tsx
+++ b/client/src/components/ui/EmptyState.tsx
@@ -1,0 +1,20 @@
+import { ReactNode } from "react";
+
+interface EmptyStateProps {
+  title: string;
+  description?: string;
+  action?: ReactNode;
+}
+
+// ui-spec.md §7 — shared shape for My Tickets' empty state (AC-12) and
+// no-results state (AC-11); the two are distinguished by the title/
+// description text the caller passes in, not by this component's markup.
+export function EmptyState({ title, description, action }: EmptyStateProps) {
+  return (
+    <div className="zen-empty-state">
+      <p style={{ fontWeight: 600, fontSize: "var(--zen-fs-h2)", margin: 0 }}>{title}</p>
+      {description && <p style={{ margin: 0 }}>{description}</p>}
+      {action}
+    </div>
+  );
+}

--- a/client/src/components/ui/Select.tsx
+++ b/client/src/components/ui/Select.tsx
@@ -1,0 +1,73 @@
+import { SelectHTMLAttributes, useId } from "react";
+
+interface SelectOption {
+  value: string;
+  label: string;
+}
+
+interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
+  label: string;
+  options: SelectOption[];
+  placeholder?: string;
+  error?: string;
+}
+
+// Native <select> deliberately (not a custom widget) so keyboard and
+// screen-reader behavior come for free (ui-spec.md §5).
+export function Select({
+  label,
+  options,
+  placeholder,
+  error,
+  required,
+  id,
+  className = "",
+  ...rest
+}: SelectProps) {
+  const generatedId = useId();
+  const fieldId = id ?? generatedId;
+  const errorId = `${fieldId}-error`;
+
+  const wrapperClasses = ["zen-field", error ? "zen-field-invalid" : "", className]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div className={wrapperClasses}>
+      <label htmlFor={fieldId} className="zen-field-label">
+        {label}
+        {required && (
+          <span className="zen-field-required-marker" aria-hidden="true">
+            {" "}
+            *
+          </span>
+        )}
+      </label>
+      <select
+        id={fieldId}
+        className="zen-field-control"
+        required={required}
+        aria-required={required || undefined}
+        aria-invalid={error ? true : undefined}
+        aria-describedby={error ? errorId : undefined}
+        {...rest}
+      >
+        {placeholder && (
+          <option value="" disabled>
+            {placeholder}
+          </option>
+        )}
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+      {error && (
+        <p id={errorId} className="zen-field-error" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/ui/Spinner.tsx
+++ b/client/src/components/ui/Spinner.tsx
@@ -1,0 +1,14 @@
+interface SpinnerProps {
+  label?: string;
+}
+
+// Standalone loading indicator (distinct from Button's inline busy spinner)
+// for whole-screen/section loading states.
+export function Spinner({ label = "Loading…" }: SpinnerProps) {
+  return (
+    <div role="status" style={{ display: "flex", alignItems: "center", gap: "var(--zen-space-2)" }}>
+      <span className="zen-spinner" aria-hidden="true" />
+      <span>{label}</span>
+    </div>
+  );
+}

--- a/client/src/components/ui/TextArea.tsx
+++ b/client/src/components/ui/TextArea.tsx
@@ -1,0 +1,70 @@
+import { TextareaHTMLAttributes, useId } from "react";
+
+interface TextAreaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  label: string;
+  error?: string;
+  caption?: string;
+}
+
+// Same field-state rules as TextField (ui-spec.md §3), sized for
+// Description: taller, vertically resizable only.
+export function TextArea({
+  label,
+  error,
+  caption,
+  required,
+  readOnly,
+  id,
+  className = "",
+  ...rest
+}: TextAreaProps) {
+  const generatedId = useId();
+  const fieldId = id ?? generatedId;
+  const errorId = `${fieldId}-error`;
+  const captionId = `${fieldId}-caption`;
+
+  const wrapperClasses = [
+    "zen-field",
+    readOnly ? "zen-field-readonly" : "",
+    error ? "zen-field-invalid" : "",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div className={wrapperClasses}>
+      <label htmlFor={fieldId} className="zen-field-label">
+        {label}
+        {required && (
+          <span className="zen-field-required-marker" aria-hidden="true">
+            {" "}
+            *
+          </span>
+        )}
+      </label>
+      <textarea
+        id={fieldId}
+        className="zen-field-control"
+        required={required}
+        aria-required={required || undefined}
+        readOnly={readOnly}
+        aria-invalid={error ? true : undefined}
+        aria-describedby={error ? errorId : caption ? captionId : undefined}
+        rows={6}
+        {...rest}
+      />
+      {error ? (
+        <p id={errorId} className="zen-field-error" role="alert">
+          {error}
+        </p>
+      ) : (
+        caption && (
+          <p id={captionId} className="zen-field-caption">
+            {caption}
+          </p>
+        )
+      )}
+    </div>
+  );
+}

--- a/client/src/components/ui/TextField.tsx
+++ b/client/src/components/ui/TextField.tsx
@@ -1,0 +1,73 @@
+import { InputHTMLAttributes, useId } from "react";
+
+// Issue 23 — reusable field per ui-spec.md §3: label above control, red
+// asterisk + aria-required on required fields (never the asterisk alone),
+// read-only fields visually distinct, error message anchored under the
+// field via aria-describedby (AC-18).
+interface TextFieldProps extends InputHTMLAttributes<HTMLInputElement> {
+  label: string;
+  error?: string;
+  caption?: string;
+  readOnlyReason?: string;
+}
+
+export function TextField({
+  label,
+  error,
+  caption,
+  readOnlyReason,
+  required,
+  readOnly,
+  id,
+  className = "",
+  ...rest
+}: TextFieldProps) {
+  const generatedId = useId();
+  const fieldId = id ?? generatedId;
+  const errorId = `${fieldId}-error`;
+  const captionId = `${fieldId}-caption`;
+
+  const wrapperClasses = [
+    "zen-field",
+    readOnly ? "zen-field-readonly" : "",
+    error ? "zen-field-invalid" : "",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div className={wrapperClasses}>
+      <label htmlFor={fieldId} className="zen-field-label">
+        {label}
+        {required && (
+          <span className="zen-field-required-marker" aria-hidden="true">
+            {" "}
+            *
+          </span>
+        )}
+      </label>
+      <input
+        id={fieldId}
+        className="zen-field-control"
+        required={required}
+        aria-required={required || undefined}
+        readOnly={readOnly}
+        aria-invalid={error ? true : undefined}
+        aria-describedby={error ? errorId : caption || readOnlyReason ? captionId : undefined}
+        {...rest}
+      />
+      {error ? (
+        <p id={errorId} className="zen-field-error" role="alert">
+          {error}
+        </p>
+      ) : (
+        (caption || readOnlyReason) && (
+          <p id={captionId} className="zen-field-caption">
+            {readOnlyReason ?? caption}
+          </p>
+        )
+      )}
+    </div>
+  );
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,10 +1,17 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
 import "bootstrap/dist/css/bootstrap.min.css";
-import App from "./App.js";
+import "./styles/zen-green.css";
+import { AppRouter } from "./AppRouter.js";
 
+// Lab 1's App.tsx (the "Check System" demo) is superseded by the Lab 2
+// Requester-facing screens below, but it and its test are left intact —
+// see client/tests/lab-01/App.test.tsx, which renders <App /> directly.
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <AppRouter />
+    </BrowserRouter>
   </React.StrictMode>
 );

--- a/client/src/pages/CreateTicketPage.tsx
+++ b/client/src/pages/CreateTicketPage.tsx
@@ -1,0 +1,10 @@
+// Placeholder route target for Issue 23's router skeleton.
+// Real implementation is Issue 27 — see docs/lab-02/ui-spec.md §6.
+export function CreateTicketPage() {
+  return (
+    <div>
+      <h1 style={{ fontSize: "var(--zen-fs-h1)" }}>Create Ticket</h1>
+      <p>Implemented in Issue 27.</p>
+    </div>
+  );
+}

--- a/client/src/pages/MyTicketsPage.tsx
+++ b/client/src/pages/MyTicketsPage.tsx
@@ -1,0 +1,10 @@
+// Placeholder route target for Issue 23's router skeleton.
+// Real implementation is Issue 29 — see docs/lab-02/ui-spec.md §7.
+export function MyTicketsPage() {
+  return (
+    <div>
+      <h1 style={{ fontSize: "var(--zen-fs-h1)" }}>My Tickets</h1>
+      <p>Implemented in Issue 29.</p>
+    </div>
+  );
+}

--- a/client/src/pages/RequesterSelectPage.tsx
+++ b/client/src/pages/RequesterSelectPage.tsx
@@ -1,0 +1,11 @@
+// Placeholder route target for Issue 23's router skeleton.
+// Real implementation (loading/empty/failure states, selector, Continue) is
+// Issue 25 — see docs/lab-02/ui-spec.md §5 and specification.md AC-02/15/16.
+export function RequesterSelectPage() {
+  return (
+    <div>
+      <h1 style={{ fontSize: "var(--zen-fs-h1)" }}>Select a Development Requester</h1>
+      <p>Implemented in Issue 25.</p>
+    </div>
+  );
+}

--- a/client/src/pages/TicketDetailPage.tsx
+++ b/client/src/pages/TicketDetailPage.tsx
@@ -1,0 +1,10 @@
+// Placeholder route target for Issue 23's router skeleton.
+// Real implementation is Issue 30 — see docs/lab-02/ui-spec.md §8.
+export function TicketDetailPage() {
+  return (
+    <div>
+      <h1 style={{ fontSize: "var(--zen-fs-h1)" }}>Ticket Detail</h1>
+      <p>Implemented in Issue 30.</p>
+    </div>
+  );
+}

--- a/client/src/styles/zen-green.css
+++ b/client/src/styles/zen-green.css
@@ -1,0 +1,345 @@
+/* Zen Green Theme tokens — see docs/lab-02/ui-spec.md §1-3.
+   Components consume these custom properties, never a literal hex value, so
+   client/tests/lab-02/zen-green.style.test.tsx can assert on class/token use. */
+
+:root {
+  /* Color */
+  --zen-primary: #006b3c;
+  --zen-secondary: #0b7a46;
+  --zen-pale: #eaf6ef;
+  --zen-page-bg: #f5f7f6;
+  --zen-surface: #ffffff;
+  --zen-border: #d9e4dd;
+  --zen-text: #16261e;
+  --zen-text-muted: #5b6b62;
+  --zen-field-editable-bg: #ffffff;
+  --zen-field-readonly-bg: #eff2ed;
+  --zen-error: #8a1f1f;
+  --zen-error-bg: #fbeded;
+  --zen-warning: #8a5a00;
+  --zen-warning-bg: #fbf2df;
+  --zen-success: #0b7a46;
+  --zen-success-bg: #eaf6ef;
+
+  /* Typography */
+  --zen-fs-h1: 1.5rem;
+  --zen-fs-h2: 1.125rem;
+  --zen-fs-body: 0.9375rem;
+  --zen-fs-label: 0.8125rem;
+  --zen-fs-caption: 0.75rem;
+
+  /* Spacing scale */
+  --zen-space-1: 4px;
+  --zen-space-2: 8px;
+  --zen-space-3: 12px;
+  --zen-space-4: 16px;
+  --zen-space-5: 24px;
+  --zen-space-6: 32px;
+  --zen-space-7: 48px;
+}
+
+body {
+  background: var(--zen-page-bg);
+  color: var(--zen-text);
+  font-size: var(--zen-fs-body);
+}
+
+/* ---------------------------------------------------------------- Buttons */
+
+.zen-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--zen-space-2);
+  min-height: 40px;
+  padding: 0 var(--zen-space-4);
+  border-radius: 6px;
+  font-size: var(--zen-fs-body);
+  font-weight: 600;
+  border: 1.5px solid transparent;
+  cursor: pointer;
+}
+
+.zen-btn:focus-visible {
+  outline: 2px solid var(--zen-secondary);
+  outline-offset: 2px;
+}
+
+.zen-btn-primary {
+  background: var(--zen-primary);
+  color: #ffffff;
+}
+
+.zen-btn-secondary {
+  background: transparent;
+  color: var(--zen-secondary);
+  border-color: var(--zen-secondary);
+}
+
+.zen-btn-tertiary {
+  background: transparent;
+  color: var(--zen-secondary);
+  border-color: transparent;
+  text-decoration: underline;
+}
+
+.zen-btn-destructive {
+  background: transparent;
+  color: var(--zen-error);
+  border-color: var(--zen-error);
+}
+
+.zen-btn:disabled,
+.zen-btn[aria-disabled="true"] {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.zen-btn-busy {
+  opacity: 0.85;
+  cursor: wait;
+}
+
+/* ----------------------------------------------------------------- Fields */
+
+.zen-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--zen-space-1);
+  margin-bottom: var(--zen-space-4);
+}
+
+.zen-field-label {
+  font-size: var(--zen-fs-label);
+  font-weight: 600;
+  color: var(--zen-text-muted);
+}
+
+.zen-field-required-marker {
+  color: var(--zen-error);
+  margin-left: 2px;
+}
+
+.zen-field-control {
+  min-height: 40px;
+  padding: 0 var(--zen-space-3);
+  border: 1px solid var(--zen-border);
+  border-radius: 6px;
+  background: var(--zen-field-editable-bg);
+  color: var(--zen-text);
+  font-size: var(--zen-fs-body);
+}
+
+textarea.zen-field-control {
+  min-height: 132px;
+  padding-top: var(--zen-space-2);
+  resize: vertical;
+}
+
+.zen-field-control:focus-visible {
+  outline: 2px solid var(--zen-secondary);
+  outline-offset: 2px;
+}
+
+.zen-field-readonly .zen-field-control {
+  background: var(--zen-field-readonly-bg);
+  color: var(--zen-text-muted);
+  cursor: default;
+}
+
+.zen-field-caption {
+  font-size: var(--zen-fs-caption);
+  color: var(--zen-text-muted);
+}
+
+.zen-field-invalid .zen-field-control {
+  border-color: var(--zen-error);
+  border-width: 2px;
+  background: var(--zen-error-bg);
+}
+
+.zen-field-error {
+  font-size: var(--zen-fs-caption);
+  color: var(--zen-error);
+}
+
+/* ------------------------------------------------------------------ Badge */
+
+.zen-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px var(--zen-space-2);
+  border-radius: 999px;
+  font-size: var(--zen-fs-caption);
+  font-weight: 600;
+}
+
+.zen-badge-neutral {
+  background: var(--zen-field-readonly-bg);
+  color: var(--zen-text-muted);
+}
+
+.zen-badge-warning {
+  background: var(--zen-warning-bg);
+  color: var(--zen-warning);
+}
+
+.zen-badge-error {
+  background: var(--zen-error-bg);
+  color: var(--zen-error);
+}
+
+.zen-badge-secondary {
+  background: var(--zen-pale);
+  color: var(--zen-secondary);
+}
+
+.zen-badge-success {
+  background: var(--zen-success-bg);
+  color: var(--zen-success);
+}
+
+/* ------------------------------------------------------------------ Alert */
+
+.zen-alert {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--zen-space-2);
+  padding: var(--zen-space-3) var(--zen-space-4);
+  border-radius: 6px;
+  border: 1px solid transparent;
+  font-size: var(--zen-fs-body);
+}
+
+.zen-alert-error {
+  background: var(--zen-error-bg);
+  color: var(--zen-error);
+  border-color: var(--zen-error);
+}
+
+.zen-alert-warning {
+  background: var(--zen-warning-bg);
+  color: var(--zen-warning);
+  border-color: var(--zen-warning);
+}
+
+.zen-alert-success {
+  background: var(--zen-success-bg);
+  color: var(--zen-success);
+  border-color: var(--zen-success);
+}
+
+/* --------------------------------------------------------------- Spinner */
+
+.zen-spinner {
+  width: 1em;
+  height: 1em;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: zen-spin 0.7s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .zen-spinner {
+    animation-duration: 1.6s;
+  }
+}
+
+@keyframes zen-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* ----------------------------------------------------------------- Empty */
+
+.zen-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--zen-space-3);
+  padding: var(--zen-space-7) var(--zen-space-4);
+  text-align: center;
+  color: var(--zen-text-muted);
+}
+
+/* ------------------------------------------------------------------ Shell */
+
+.zen-shell-header {
+  background: var(--zen-primary);
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--zen-space-4);
+  padding: var(--zen-space-3) var(--zen-space-4);
+}
+
+.zen-shell-wordmark {
+  font-weight: 700;
+  font-size: var(--zen-fs-h2);
+  color: #ffffff;
+  text-decoration: none;
+}
+
+.zen-shell-nav {
+  display: flex;
+  gap: var(--zen-space-4);
+}
+
+.zen-shell-nav-link {
+  color: #ffffff;
+  text-decoration: none;
+  font-weight: 500;
+  padding-bottom: 2px;
+  border-bottom: 2px solid transparent;
+}
+
+.zen-shell-nav-link-active {
+  border-bottom-color: var(--zen-pale);
+  font-weight: 600;
+}
+
+.zen-shell-requester {
+  display: flex;
+  align-items: center;
+  gap: var(--zen-space-3);
+  color: #ffffff;
+  font-size: var(--zen-fs-caption);
+}
+
+.zen-shell-hamburger {
+  display: none;
+}
+
+.zen-shell-main {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: var(--zen-space-5) var(--zen-space-4);
+}
+
+@media (max-width: 767px) {
+  .zen-shell-nav {
+    display: none;
+  }
+
+  .zen-shell-nav.zen-shell-nav-open {
+    display: flex;
+    flex-direction: column;
+    position: absolute;
+    top: 56px;
+    left: 0;
+    right: 0;
+    background: var(--zen-primary);
+    padding: var(--zen-space-3) var(--zen-space-4);
+    gap: var(--zen-space-3);
+    z-index: 10;
+  }
+
+  .zen-shell-hamburger {
+    display: inline-flex;
+  }
+}

--- a/client/tests/lab-02/zen-green.style.test.tsx
+++ b/client/tests/lab-02/zen-green.style.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { TextField } from "../../src/components/ui/TextField.js";
+import { Button } from "../../src/components/ui/Button.js";
+import { AppShell } from "../../src/components/shell/AppShell.js";
+
+// Covers STYLE-01 through STYLE-05 in docs/lab-02/tests.md: asserts on the
+// required classes/tokens/attributes of the reusable Zen Green components,
+// not on pixel values. Every Lab 2 screen reuses these components, so these
+// tests are the single source of truth for the component-level rules in
+// docs/lab-02/ui-spec.md §3.
+describe("Zen Green component states", () => {
+  // STYLE-01
+  it("a required field shows the asterisk AND sets aria-required", () => {
+    render(<TextField label="Summary" name="summary" required />);
+    const input = screen.getByLabelText(/summary/i);
+    expect(input).toHaveAttribute("aria-required", "true");
+    expect(screen.getByText("*")).toBeInTheDocument();
+  });
+
+  // STYLE-02
+  it("a read-only field is visually distinct from an editable field", () => {
+    const { container: editableContainer } = render(<TextField label="Summary" name="summary" />);
+    const { container: readOnlyContainer } = render(
+      <TextField label="Ticket Number" name="ticketNumber" readOnly value="(assigned after submission)" />,
+    );
+
+    const editableWrapper = editableContainer.querySelector(".zen-field");
+    const readOnlyWrapper = readOnlyContainer.querySelector(".zen-field");
+
+    expect(editableWrapper).not.toHaveClass("zen-field-readonly");
+    expect(readOnlyWrapper).toHaveClass("zen-field-readonly");
+  });
+
+  // STYLE-03
+  it("a disabled button is visually distinct and does not fire its handler", async () => {
+    const onClick = vi.fn();
+    render(
+      <Button variant="primary" disabled onClick={onClick}>
+        Submit Ticket
+      </Button>,
+    );
+    const button = screen.getByRole("button", { name: /submit ticket/i });
+    expect(button).toBeDisabled();
+
+    const user = userEvent.setup();
+    await user.click(button);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  // STYLE-04
+  it("an icon-only control has both an accessible label and a tooltip", () => {
+    render(
+      <MemoryRouter>
+        <AppShell>
+          <div />
+        </AppShell>
+      </MemoryRouter>,
+    );
+    const hamburger = screen.getByRole("button", { name: /open navigation menu/i });
+    expect(hamburger).toHaveAttribute("aria-label");
+    expect(hamburger).toHaveAttribute("title");
+  });
+
+  // STYLE-05
+  it("an invalid field's error message id matches the field's aria-describedby", () => {
+    render(
+      <TextField label="Summary" name="summary" required error="Summary must be 5-120 characters." />,
+    );
+    const input = screen.getByLabelText(/summary/i);
+    const describedBy = input.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+
+    const errorMessage = screen.getByRole("alert");
+    expect(errorMessage).toHaveAttribute("id", describedBy);
+    expect(errorMessage).toHaveTextContent("Summary must be 5-120 characters.");
+  });
+
+  it("a busy button replaces its label and disables itself", () => {
+    render(
+      <Button variant="primary" busy busyText="Submitting…">
+        Submit Ticket
+      </Button>,
+    );
+    expect(screen.queryByText("Submit Ticket")).not.toBeInTheDocument();
+    expect(screen.getByText("Submitting…")).toBeInTheDocument();
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+});

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -8,6 +8,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "noEmit": true,
     "types": ["vitest/globals", "@testing-library/jest-dom"]
   },
   "include": ["src", "tests"]

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -56,11 +56,11 @@ Criterion in `specification.md` §9 maps to at least one row below.
 | UI-13 | UI component | §8 (attachments list) | Ticket Detail with 1 active + 1 removed attachment mocked | Active row has a working Download button; removed row shows its `removalReason` instead of action buttons | `client/tests/lab-02/AttachmentSection.test.tsx` | Planned |
 | UI-14 | UI component | AC-09 | Click Remove on an active attachment, submit without typing a reason | Client-side validation blocks submission; no DELETE fired | `client/tests/lab-02/AttachmentSection.test.tsx` | Planned |
 | UI-15 | UI component | AC-09 | Remove an attachment with a valid reason, mocked success | Attachment row updates to Removed badge + shows the reason | `client/tests/lab-02/AttachmentSection.test.tsx` | Planned |
-| STYLE-01 | UI style | §1, §3 | Required field renders | Has the asterisk element AND `aria-required="true"` (not just one) | `client/tests/lab-02/zen-green.style.test.tsx` | Planned |
-| STYLE-02 | UI style | §3 | Read-only field (Ticket Number on Create Ticket) | Has the read-only field class/token, distinct from an editable field's class | `client/tests/lab-02/zen-green.style.test.tsx` | Planned |
-| STYLE-03 | UI style | §3 | Disabled button | Has `disabled` attribute and the disabled visual class; click handler does not fire | `client/tests/lab-02/zen-green.style.test.tsx` | Planned |
-| STYLE-04 | UI style | §3 | Icon-only control (attachment remove trash icon) | Has an `aria-label` and a `title` | `client/tests/lab-02/zen-green.style.test.tsx` | Planned |
-| STYLE-05 | UI style | §3 | Invalid field | Error message element's `id` matches the field's `aria-describedby` | `client/tests/lab-02/zen-green.style.test.tsx` | Planned |
+| STYLE-01 | UI style | §1, §3 | Required field renders | Has the asterisk element AND `aria-required="true"` (not just one) | `client/tests/lab-02/zen-green.style.test.tsx` | **Pass** |
+| STYLE-02 | UI style | §3 | Read-only field (Ticket Number on Create Ticket) | Has the read-only field class/token, distinct from an editable field's class | `client/tests/lab-02/zen-green.style.test.tsx` | **Pass** |
+| STYLE-03 | UI style | §3 | Disabled button | Has `disabled` attribute and the disabled visual class; click handler does not fire | `client/tests/lab-02/zen-green.style.test.tsx` | **Pass** |
+| STYLE-04 | UI style | §3 | Icon-only control (attachment remove trash icon) | Has an `aria-label` and a `title` | `client/tests/lab-02/zen-green.style.test.tsx` | Planned (pattern proven on the Issue 23 nav hamburger; the attachment-remove icon itself ships in Issue 31) |
+| STYLE-05 | UI style | §3 | Invalid field | Error message element's `id` matches the field's `aria-describedby` | `client/tests/lab-02/zen-green.style.test.tsx` | **Pass** |
 | RESP-01 | Responsive | AC-17, §9 | Create Ticket at 375/820/1280px | No `document.body` horizontal scroll at any width; screenshots saved | `e2e/lab-02/responsive.spec.ts` | Planned |
 | RESP-02 | Responsive | AC-17, §9 | My Tickets at 375/820/1280px | Table renders at desktop/tablet, cards render at mobile; screenshots saved | `e2e/lab-02/responsive.spec.ts` | Planned |
 | RESP-03 | Responsive | AC-17, §9 | Ticket Detail at 375/820/1280px | Header/attachment sections both fully visible, no clipped filenames; screenshots saved | `e2e/lab-02/responsive.spec.ts` | Planned |


### PR DESCRIPTION
## Summary
Zen Green CSS tokens, reusable form/badge/alert/loading components, the app shell (nav + Requester display placeholder + mobile hamburger), and a router skeleton for all 4 Lab 2 screens, per `ui-spec.md` §1-5.

## Details
- `client/src/styles/zen-green.css`: color/typography/spacing tokens, component classes
- `components/ui/`: Button (variants + busy state), TextField, TextArea, Select, Badge, Alert, Spinner, EmptyState
- `components/shell/AppShell.tsx`: header, nav with active-page indication, mobile nav collapse < 768px
- `AppRouter.tsx` + placeholder pages for /select-requester, /tickets/new, /tickets, /tickets/:id (real screens land in Issues 25/27/29/30)
- Lab 1's `App.tsx` and its test are untouched, still passing

## Bonus fix
Found and fixed a latent scaffold bug while testing this PR: `client/tsconfig.json` had no `noEmit`/`outDir`, so `npm run build` was silently emitting compiled `.js` files next to their `.tsx` sources in `src/`. Added `noEmit: true` — Vite/esbuild does the real bundling, `tsc` is now purely a type-check gate, matching the standard Vite+TS pattern.

## Test evidence
`cd client && npm test` — 2 files, 9 tests passing (3 Lab 1 + 6 Lab 2, covering STYLE-01/02/03/05). `npm run build` succeeds with no stray output. `npx tsc --noEmit` clean.

Resolves #23

Note: this PR targets `lab2-staging`, not the default branch, so the keyword above shows as a mention only. Link it to Issue 23 manually via the Development panel per the TokTickIT GitHub Workflow Guide.