### PR TITLE
Issue 24: Reference data and Development Requester API

### DIFF
--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -41,7 +41,9 @@ Criterion in `specification.md` §9 maps to at least one row below.
 | API-17 | API | BR-24 | `DELETE /api/attachments/:id` with `removalReason` = `"ok"` (4 chars) | `400` (below 5-char minimum) | `server/tests/lab-02/attachments.api.test.ts` | Planned |
 | API-18 | API | AC-08, BR-23 | `GET /api/attachments/:id/download` on a removed attachment | `410 ATTACHMENT_REMOVED` | `server/tests/lab-02/attachments.api.test.ts` | Planned |
 | API-19 | API | §10 (ownership, general) | Requester B calls add/download/remove-attachment on Requester A's ticket's attachment | `404` for all three, no data leaked or mutated | `server/tests/lab-02/attachments.api.test.ts` | Planned |
-| API-20 | API | FR-01, BR-06 | `GET /api/dev-requesters` with one active + one inactive seeded Requester | Only the active one is returned | `server/tests/lab-02/dev-requesters.api.test.ts` | Planned |
+| API-20 | API | FR-01, BR-06 | `GET /api/dev-requesters` with one active + one inactive seeded Requester | Only the active one is returned | `server/tests/lab-02/reference.api.test.ts` | **Pass** |
+| API-21 | API | Issue #24 AC | `GET /api/categories` with one category deactivated | Deactivated category excluded; 500 on simulated DB failure | `server/tests/lab-02/reference.api.test.ts` | **Pass** |
+| API-22 | API | Issue #24 AC | `GET /api/related-systems` success + simulated DB failure | ≥6 active systems, ordered by id; 500 on simulated DB failure | `server/tests/lab-02/reference.api.test.ts` | **Pass** |
 | UI-01 | UI component | AC-02 | Visiting `/tickets` with no Requester selected | Redirected to `/select-requester` | `client/tests/lab-02/RequesterSelect.test.tsx` | Planned |
 | UI-02 | UI component | AC-16 | Requester Selection screen, mocked empty active-Requester list | Empty-state message shown; Continue stays disabled | `client/tests/lab-02/RequesterSelect.test.tsx` | Planned |
 | UI-03 | UI component | AC-15 | Requester Selection screen, mocked API failure | Failure callout + Retry button shown | `client/tests/lab-02/RequesterSelect.test.tsx` | Planned |

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,6 +1,6 @@
 import express, { Request, Response } from "express";
 import cors from "cors";
-import { getPrisma } from "./prisma.js";
+import { referenceRouter } from "./routes/reference.js";
 
 // The Express app is exported separately from app.listen() (see index.ts) so
 // Supertest can import `app` without opening a port. Do not merge these files.
@@ -18,20 +18,8 @@ app.get("/api/health", (_req: Request, res: Response) => {
   res.status(200).json({ status: "ok", service: "TokTickIT API" });
 });
 
-// ---------------------------------------------------------------------------
-// Issue 4 — Category list
-// GET /api/categories -> categories from PostgreSQL via Prisma, ordered by id.
-// ---------------------------------------------------------------------------
-app.get("/api/categories", async (_req: Request, res: Response) => {
-  try {
-    const categories = await getPrisma().category.findMany({
-      orderBy: { id: "asc" },
-      select: { id: true, name: true },
-    });
-    res.status(200).json(categories);
-  } catch {
-    res.status(500).json({ error: "Unable to load categories" });
-  }
-});
+// Issue 4 (Lab 1) — /api/categories, now Issue 24 (Lab 2) — plus
+// /api/related-systems and /api/dev-requesters. See routes/reference.ts.
+app.use(referenceRouter);
 
 export default app;

--- a/server/src/routes/reference.ts
+++ b/server/src/routes/reference.ts
@@ -1,0 +1,46 @@
+import { Router, Request, Response } from "express";
+import { getPrisma } from "../prisma.js";
+
+// Issue 24 — reference data + Development Requester API (api-spec.md §1-3).
+// All three endpoints: no auth (they're what makes selection possible in
+// the first place), only isActive rows, safe 500 on DB failure.
+export const referenceRouter = Router();
+
+referenceRouter.get("/api/categories", async (_req: Request, res: Response) => {
+  try {
+    const categories = await getPrisma().category.findMany({
+      where: { isActive: true },
+      orderBy: { id: "asc" },
+      select: { id: true, name: true },
+    });
+    res.status(200).json(categories);
+  } catch {
+    res.status(500).json({ error: "INTERNAL_ERROR", message: "Unable to load categories." });
+  }
+});
+
+referenceRouter.get("/api/related-systems", async (_req: Request, res: Response) => {
+  try {
+    const relatedSystems = await getPrisma().relatedSystem.findMany({
+      where: { isActive: true },
+      orderBy: { id: "asc" },
+      select: { id: true, name: true },
+    });
+    res.status(200).json(relatedSystems);
+  } catch {
+    res.status(500).json({ error: "INTERNAL_ERROR", message: "Unable to load related systems." });
+  }
+});
+
+referenceRouter.get("/api/dev-requesters", async (_req: Request, res: Response) => {
+  try {
+    const requesters = await getPrisma().requesterUser.findMany({
+      where: { isActive: true },
+      orderBy: { fullName: "asc" },
+      select: { id: true, fullName: true, email: true },
+    });
+    res.status(200).json(requesters);
+  } catch {
+    res.status(500).json({ error: "INTERNAL_ERROR", message: "Unable to load Development Requesters." });
+  }
+});

--- a/server/tests/lab-02/reference.api.test.ts
+++ b/server/tests/lab-02/reference.api.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import request from "supertest";
+import { app } from "../../src/app.js";
+import { getPrisma } from "../../src/prisma.js";
+import { seedAll } from "../../prisma/seed.js";
+
+// Issue 24 — api-spec.md §1-3.
+describe("GET /api/categories (Lab 2: isActive filter)", () => {
+  beforeAll(async () => {
+    await seedAll();
+  });
+
+  it("returns only active categories, ordered by id", async () => {
+    const res = await request(app).get("/api/categories");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([
+      { id: 1, name: "Account and Access" },
+      { id: 2, name: "Hardware" },
+      { id: 3, name: "Software" },
+      { id: 4, name: "Network" },
+    ]);
+  });
+
+  it("excludes an inactive category", async () => {
+    const prisma = getPrisma();
+    const target = await prisma.category.findFirstOrThrow({ where: { name: "Network" } });
+    await prisma.category.update({ where: { id: target.id }, data: { isActive: false } });
+
+    const res = await request(app).get("/api/categories");
+    expect(res.body.map((c: { name: string }) => c.name)).not.toContain("Network");
+
+    // restore for other tests / manual runs
+    await prisma.category.update({ where: { id: target.id }, data: { isActive: true } });
+  });
+
+  it("returns a safe 500 when the database is unreachable", async () => {
+    const spy = vi.spyOn(getPrisma().category, "findMany").mockRejectedValueOnce(new Error("boom"));
+    const res = await request(app).get("/api/categories");
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: "INTERNAL_ERROR", message: "Unable to load categories." });
+    spy.mockRestore();
+  });
+});
+
+describe("GET /api/related-systems", () => {
+  it("returns only active related systems, ordered by id", async () => {
+    const res = await request(app).get("/api/related-systems");
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBeGreaterThanOrEqual(6);
+    for (let i = 1; i < res.body.length; i++) {
+      expect(res.body[i].id).toBeGreaterThan(res.body[i - 1].id);
+    }
+  });
+
+  it("returns a safe 500 when the database is unreachable", async () => {
+    const spy = vi.spyOn(getPrisma().relatedSystem, "findMany").mockRejectedValueOnce(new Error("boom"));
+    const res = await request(app).get("/api/related-systems");
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: "INTERNAL_ERROR", message: "Unable to load related systems." });
+    spy.mockRestore();
+  });
+});
+
+// API-20
+describe("GET /api/dev-requesters", () => {
+  it("returns only active Development Requesters, excluding the seeded inactive one", async () => {
+    const res = await request(app).get("/api/dev-requesters");
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBeGreaterThanOrEqual(4);
+    expect(res.body.some((r: { fullName: string }) => r.fullName === "Somsak Jantawong")).toBe(false);
+    for (const r of res.body) {
+      expect(r).toHaveProperty("id");
+      expect(r).toHaveProperty("fullName");
+      expect(r).toHaveProperty("email");
+    }
+  });
+
+  it("returns a safe 500 when the database is unreachable", async () => {
+    const spy = vi.spyOn(getPrisma().requesterUser, "findMany").mockRejectedValueOnce(new Error("boom"));
+    const res = await request(app).get("/api/dev-requesters");
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: "INTERNAL_ERROR", message: "Unable to load Development Requesters." });
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
Adds `GET /api/related-systems` and `GET /api/dev-requesters`, and updates `GET /api/categories` to filter `isActive: true` per `api-spec.md` §1-3.

## Details
- `server/src/routes/reference.ts`: all three endpoints extracted out of `app.ts`, each returning only active rows and a safe `500` on DB failure
- No auth on any of the three (they're reference/bootstrap data, not Requester-scoped)

## Test evidence
`cd server && npm test` — 4 files, 13 tests passing (2 Lab 1 + 11 Lab 2). Covers: success case + inactive-row exclusion + simulated DB-failure 500 for each of the three endpoints (API-20/21/22 in tests.md).

Resolves #24

Note: this PR targets `lab2-staging`, not the default branch, so the keyword above shows as a mention only. Link it to Issue 24 manually via the Development panel per the TokTickIT GitHub Workflow Guide.