### PR TITLE
Issue 26: Create Ticket API

### DIFF
--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -16,18 +16,18 @@ Criterion in `specification.md` §9 maps to at least one row below.
 
 | Test ID | Type | Requirement/AC | What It Tests | Expected Result | Automated Test File | Result |
 |---|---|---|---|---|---|---|
-| UNIT-01 | Unit | BR-01 | Ticket number format `TKT-YYYY-NNNNNN` | Matches regex, correct year | `server/tests/lab-02/ticket-number.unit.test.ts` | Planned |
-| UNIT-02 | Unit | BR-01 | 20 concurrent ticket-number generations in the same year | All 20 numbers unique | `server/tests/lab-02/ticket-number.unit.test.ts` | Planned |
-| UNIT-03 | Unit | BR-20 | File-type allowlist checker | Accepts jpg/jpeg/png/webp/pdf; rejects gif/exe/txt | `server/tests/lab-02/attachment-rules.unit.test.ts` | Planned |
-| UNIT-04 | Unit | BR-21 | File-size boundary checker | Exactly 5MB passes; 5MB+1byte rejected | `server/tests/lab-02/attachment-rules.unit.test.ts` | Planned |
-| UNIT-05 | Unit | BR-25 | Stored-filename generator | Output is a UUID + validated extension, never contains the original filename | `server/tests/lab-02/attachment-rules.unit.test.ts` | Planned |
+| UNIT-01 | Unit | BR-01 | Ticket number format `TKT-YYYY-NNNNNN` | Matches regex, correct year | `server/tests/lab-02/ticket-number.unit.test.ts` | **Pass** |
+| UNIT-02 | Unit | BR-01 | 20 concurrent ticket-number generations in the same year | All 20 numbers unique | `server/tests/lab-02/ticket-number.unit.test.ts` | **Pass** |
+| UNIT-03 | Unit | BR-20 | File-type allowlist checker | Accepts jpg/jpeg/png/webp/pdf; rejects gif/exe/txt | `server/tests/lab-02/attachment-rules.unit.test.ts` | **Pass** |
+| UNIT-04 | Unit | BR-21 | File-size boundary checker | Exactly 5MB passes; 5MB+1byte rejected | `server/tests/lab-02/attachment-rules.unit.test.ts` | **Pass** |
+| UNIT-05 | Unit | BR-25 | Stored-filename generator | Output is a UUID + validated extension, never contains the original filename | `server/tests/lab-02/attachment-rules.unit.test.ts` | **Pass** |
 | UNIT-06 | Unit | Issue #22 AC | Seed idempotency: run `seedAll()` twice against the test DB | Second run changes no row counts; 4 categories, ≥6 related systems, ≥4 active + ≥1 inactive Requester all present | `server/tests/lab-02/seed.unit.test.ts` | **Pass** |
-| API-01 | API | AC-01 | `POST /api/tickets` valid payload | `201`; response has `ticketNumber`; row exists in DB with `currentStatus=NEW` | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
-| API-02 | API | AC-04, BR-14–17 | `POST /api/tickets` missing `summary` | `400`; `fieldErrors.summary` present; no row created | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
-| API-03 | API | BR-14 | `summary` at 4 and 121 chars (boundary) | Both `400`; 5 and 120 chars both `201` | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
-| API-04 | API | BR-15 | `categoryId` referencing an inactive Category | `400` | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
-| API-05 | API | §0, BR-26 | Request with inactive Requester header | `403` | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
-| API-06 | API | BR-19 | Create with one valid + one oversized attachment | `201`; ticket saved; `attachmentErrors` lists the oversized file | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
+| API-01 | API | AC-01 | `POST /api/tickets` valid payload | `201`; response has `ticketNumber`; row exists in DB with `currentStatus=NEW` | `server/tests/lab-02/create-ticket.api.test.ts` | **Pass** |
+| API-02 | API | AC-04, BR-14–17 | `POST /api/tickets` missing `summary` | `400`; `fieldErrors.summary` present; no row created | `server/tests/lab-02/create-ticket.api.test.ts` | **Pass** |
+| API-03 | API | BR-14 | `summary` at 4 and 121 chars (boundary) | Both `400`; 5 and 120 chars both `201` | `server/tests/lab-02/create-ticket.api.test.ts` | **Pass** |
+| API-04 | API | BR-15 | `categoryId` referencing an inactive Category | `400` | `server/tests/lab-02/create-ticket.api.test.ts` | **Pass** |
+| API-05 | API | §0, BR-26 | Request with inactive Requester header | `403` | `server/tests/lab-02/create-ticket.api.test.ts` | **Pass** |
+| API-06 | API | BR-19 | Create with one valid + one oversized attachment | `201`; ticket saved; `attachmentErrors` lists the oversized file | `server/tests/lab-02/create-ticket.api.test.ts` | **Pass** |
 | API-07 | API | AC-10, BR-09 | `GET /api/tickets` as Requester A vs Requester B | Each sees only their own tickets | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
 | API-08 | API | BR-11 | `search=` matching a `ticketNumber` and separately a `summary` substring | Both return the matching ticket; unrelated tickets excluded | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
 | API-09 | API | BR-12 | Two tickets with identical `createdAt`, sorted by `createdAt:desc` twice | Row order identical both times (secondary `id:desc` holds) | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,11 +10,13 @@
       "dependencies": {
         "@prisma/client": "^5.22.0",
         "cors": "^2.8.5",
-        "express": "^4.21.2"
+        "express": "^4.21.2",
+        "multer": "^2.2.0"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
+        "@types/multer": "^2.2.0",
         "@types/node": "^22.10.2",
         "@types/supertest": "^6.0.2",
         "prisma": "^5.22.0",
@@ -1065,6 +1067,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/multer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-3U1troeqGV8Ntp7Q3klwf4zr23VEoqYVocYXaswm9+8z3O9UHDYAqLxjJ/h550iRADTjKdOdhhasXw6gD6kYtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.20.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
@@ -1272,6 +1284,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -1324,6 +1342,23 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -1422,6 +1457,21 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
       }
     },
     "node_modules/content-disposition": {
@@ -2077,6 +2127,25 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.18",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
@@ -2287,6 +2356,20 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/rollup": {
@@ -2524,6 +2607,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/superagent": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
@@ -2693,6 +2793,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -2722,6 +2828,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/server/package.json
+++ b/server/package.json
@@ -17,11 +17,13 @@
   "dependencies": {
     "@prisma/client": "^5.22.0",
     "cors": "^2.8.5",
-    "express": "^4.21.2"
+    "express": "^4.21.2",
+    "multer": "^2.2.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
+    "@types/multer": "^2.2.0",
     "@types/node": "^22.10.2",
     "@types/supertest": "^6.0.2",
     "prisma": "^5.22.0",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,6 +1,7 @@
 import express, { Request, Response } from "express";
 import cors from "cors";
 import { referenceRouter } from "./routes/reference.js";
+import { ticketsRouter } from "./routes/tickets.js";
 
 // The Express app is exported separately from app.listen() (see index.ts) so
 // Supertest can import `app` without opening a port. Do not merge these files.
@@ -21,5 +22,8 @@ app.get("/api/health", (_req: Request, res: Response) => {
 // Issue 4 (Lab 1) — /api/categories, now Issue 24 (Lab 2) — plus
 // /api/related-systems and /api/dev-requesters. See routes/reference.ts.
 app.use(referenceRouter);
+
+// Issue 26 — POST /api/tickets. See routes/tickets.ts.
+app.use(ticketsRouter);
 
 export default app;

--- a/server/src/lib/attachmentRules.ts
+++ b/server/src/lib/attachmentRules.ts
@@ -1,0 +1,50 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+
+// Issue 26/31 — BR-20/BR-21/BR-25. Shared by Create Ticket's inline
+// attachment handling (Issue 26) and the standalone attachment endpoints
+// (Issue 31), so the rule is defined exactly once.
+export const MAX_ATTACHMENT_BYTES = 5 * 1024 * 1024;
+export const MAX_ACTIVE_ATTACHMENTS = 5;
+
+// Both the extension AND the mimetype must match — either one alone can be
+// spoofed by renaming a file or forging a Content-Type header.
+const ALLOWED: Record<string, string[]> = {
+  ".jpg": ["image/jpeg"],
+  ".jpeg": ["image/jpeg"],
+  ".png": ["image/png"],
+  ".webp": ["image/webp"],
+  ".pdf": ["application/pdf"],
+};
+
+export type AttachmentRejectReason = "TYPE" | "SIZE";
+
+export function checkAttachmentFile(
+  originalname: string,
+  mimetype: string,
+  sizeBytes: number,
+): { ok: true } | { ok: false; reason: AttachmentRejectReason; message: string } {
+  if (sizeBytes > MAX_ATTACHMENT_BYTES) {
+    return { ok: false, reason: "SIZE", message: `File exceeds the ${MAX_ATTACHMENT_BYTES / 1024 / 1024}MB limit.` };
+  }
+
+  const ext = path.extname(originalname).toLowerCase();
+  const allowedMimes = ALLOWED[ext];
+  if (!allowedMimes || !allowedMimes.includes(mimetype)) {
+    return {
+      ok: false,
+      reason: "TYPE",
+      message: "Only JPG, JPEG, PNG, WEBP, and PDF files are allowed.",
+    };
+  }
+
+  return { ok: true };
+}
+
+// BR-25 — the stored filename is a generated UUID plus the validated
+// extension; the Requester-supplied original filename is display metadata
+// only and is never used to build a filesystem path.
+export function generateStoredFilename(originalname: string): string {
+  const ext = path.extname(originalname).toLowerCase();
+  return `${randomUUID()}${ext}`;
+}

--- a/server/src/lib/attachmentStorage.ts
+++ b/server/src/lib/attachmentStorage.ts
@@ -1,0 +1,18 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Issue 26/31 — local disk storage under server/uploads/ (gitignored).
+// specification.md §11: acceptable for a course lab; a production system
+// would use object storage, explicitly out of scope here.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const UPLOADS_DIR = path.resolve(__dirname, "../../uploads");
+
+export async function saveAttachmentFile(storedFilename: string, buffer: Buffer): Promise<void> {
+  await mkdir(UPLOADS_DIR, { recursive: true });
+  await writeFile(path.join(UPLOADS_DIR, storedFilename), buffer);
+}
+
+export function attachmentFilePath(storedFilename: string): string {
+  return path.join(UPLOADS_DIR, storedFilename);
+}

--- a/server/src/lib/ticketNumber.ts
+++ b/server/src/lib/ticketNumber.ts
@@ -1,0 +1,20 @@
+import { Prisma } from "@prisma/client";
+
+// Issue 26 — BR-01: TKT-YYYY-NNNNNN, generated inside the same transaction
+// that inserts the Ticket, via a per-year TicketCounter row, so concurrent
+// creations in the same year can never collide.
+export async function nextTicketNumber(
+  tx: Prisma.TransactionClient,
+  now: Date = new Date(),
+): Promise<string> {
+  const year = now.getUTCFullYear();
+
+  const counter = await tx.ticketCounter.upsert({
+    where: { year },
+    create: { year, lastValue: 1 },
+    update: { lastValue: { increment: 1 } },
+  });
+
+  const sequence = String(counter.lastValue).padStart(6, "0");
+  return `TKT-${year}-${sequence}`;
+}

--- a/server/src/lib/ticketValidation.ts
+++ b/server/src/lib/ticketValidation.ts
@@ -1,0 +1,81 @@
+// Issue 26 — BR-14/BR-15 field validation for POST /api/tickets.
+// Returns a fieldErrors map (empty if valid) so the route handler can build
+// the api-spec.md §4 VALIDATION_FAILED response directly from it.
+export const PRIORITIES = ["LOW", "MEDIUM", "HIGH", "URGENT"] as const;
+export type Priority = (typeof PRIORITIES)[number];
+
+export interface CreateTicketInput {
+  summary?: unknown;
+  description?: unknown;
+  categoryId?: unknown;
+  relatedSystemId?: unknown;
+  requestedPriority?: unknown;
+}
+
+export interface ValidatedCreateTicket {
+  summary: string;
+  description: string;
+  categoryId: number;
+  relatedSystemId: number;
+  requestedPriority: Priority;
+}
+
+interface ValidationResult {
+  ok: boolean;
+  fieldErrors: Record<string, string>;
+  value?: ValidatedCreateTicket;
+}
+
+function toPositiveInt(value: unknown): number | null {
+  const n = typeof value === "string" ? Number(value) : value;
+  return typeof n === "number" && Number.isInteger(n) && n > 0 ? n : null;
+}
+
+export function validateCreateTicketInput(input: CreateTicketInput): ValidationResult {
+  const fieldErrors: Record<string, string> = {};
+
+  const summary = typeof input.summary === "string" ? input.summary.trim() : "";
+  if (summary.length < 5 || summary.length > 120) {
+    fieldErrors.summary = "Summary must be 5-120 characters.";
+  }
+
+  const description = typeof input.description === "string" ? input.description.trim() : "";
+  if (description.length < 20 || description.length > 4000) {
+    fieldErrors.description = "Description must be 20-4000 characters.";
+  }
+
+  const categoryId = toPositiveInt(input.categoryId);
+  if (categoryId === null) {
+    fieldErrors.categoryId = "Select a category.";
+  }
+
+  const relatedSystemId = toPositiveInt(input.relatedSystemId);
+  if (relatedSystemId === null) {
+    fieldErrors.relatedSystemId = "Select a related system.";
+  }
+
+  const requestedPriority =
+    typeof input.requestedPriority === "string" &&
+    (PRIORITIES as readonly string[]).includes(input.requestedPriority)
+      ? (input.requestedPriority as Priority)
+      : null;
+  if (requestedPriority === null) {
+    fieldErrors.requestedPriority = "Select a requested priority.";
+  }
+
+  if (Object.keys(fieldErrors).length > 0) {
+    return { ok: false, fieldErrors };
+  }
+
+  return {
+    ok: true,
+    fieldErrors: {},
+    value: {
+      summary,
+      description,
+      categoryId: categoryId!,
+      relatedSystemId: relatedSystemId!,
+      requestedPriority: requestedPriority!,
+    },
+  };
+}

--- a/server/src/middleware/requesterAuth.ts
+++ b/server/src/middleware/requesterAuth.ts
@@ -1,0 +1,54 @@
+import { NextFunction, Request, Response } from "express";
+import { getPrisma } from "../prisma.js";
+
+// Issue 26 — resolves X-Dev-Requester-Id into req.requester for every
+// Requester-scoped endpoint (api-spec.md §0). This is a Lab 2 testing
+// mechanism, not authentication — see specification.md BR-05/BR-29.
+export interface AuthedRequester {
+  id: number;
+  fullName: string;
+  isActive: boolean;
+}
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      requester?: AuthedRequester;
+    }
+  }
+}
+
+export async function requesterAuth(req: Request, res: Response, next: NextFunction) {
+  const header = req.header("X-Dev-Requester-Id");
+  const id = header ? Number(header) : NaN;
+
+  if (!header || !Number.isInteger(id)) {
+    res.status(400).json({
+      error: "MISSING_REQUESTER",
+      message: "X-Dev-Requester-Id header is required",
+    });
+    return;
+  }
+
+  const requester = await getPrisma().requesterUser.findUnique({ where: { id } });
+
+  if (!requester) {
+    res.status(400).json({
+      error: "UNKNOWN_REQUESTER",
+      message: "No Development Requester with that id",
+    });
+    return;
+  }
+
+  if (!requester.isActive) {
+    res.status(403).json({
+      error: "REQUESTER_INACTIVE",
+      message: "This Development Requester is no longer active",
+    });
+    return;
+  }
+
+  req.requester = { id: requester.id, fullName: requester.fullName, isActive: requester.isActive };
+  next();
+}

--- a/server/src/routes/tickets.ts
+++ b/server/src/routes/tickets.ts
@@ -1,0 +1,145 @@
+import { Router, Request, Response, NextFunction } from "express";
+import multer from "multer";
+import { getPrisma } from "../prisma.js";
+import { requesterAuth } from "../middleware/requesterAuth.js";
+import { validateCreateTicketInput } from "../lib/ticketValidation.js";
+import { nextTicketNumber } from "../lib/ticketNumber.js";
+import { checkAttachmentFile, generateStoredFilename, MAX_ATTACHMENT_BYTES } from "../lib/attachmentRules.js";
+import { saveAttachmentFile } from "../lib/attachmentStorage.js";
+
+// Issue 26 — POST /api/tickets (api-spec.md §4). multipart/form-data because
+// it optionally carries files in the same request as the initial submission
+// — the one endpoint in the contract that isn't plain JSON.
+export const ticketsRouter = Router();
+
+// A generous safety-net ceiling against abuse; the real 5MB-per-file rule
+// (BR-21) is enforced per-file below so one oversized file doesn't abort
+// the whole request (BR-19 — the Ticket must still be created).
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: MAX_ATTACHMENT_BYTES * 4, files: 5 },
+});
+
+function parseAttachments(req: Request, res: Response, next: NextFunction) {
+  upload.array("attachments", 5)(req, res, (err) => {
+    if (err) {
+      res.status(400).json({ error: "UPLOAD_FAILED", message: "Could not process the uploaded files." });
+      return;
+    }
+    next();
+  });
+}
+
+ticketsRouter.post(
+  "/api/tickets",
+  requesterAuth,
+  parseAttachments,
+  async (req: Request, res: Response) => {
+    const validation = validateCreateTicketInput(req.body);
+    if (!validation.ok) {
+      res.status(400).json({
+        error: "VALIDATION_FAILED",
+        message: "Fix the highlighted fields.",
+        fieldErrors: validation.fieldErrors,
+      });
+      return;
+    }
+
+    const { summary, description, categoryId, relatedSystemId, requestedPriority } = validation.value!;
+
+    // BR-15 — the referenced Category/RelatedSystem must exist and be active.
+    const [category, relatedSystem] = await Promise.all([
+      getPrisma().category.findFirst({ where: { id: categoryId, isActive: true } }),
+      getPrisma().relatedSystem.findFirst({ where: { id: relatedSystemId, isActive: true } }),
+    ]);
+    const fieldErrors: Record<string, string> = {};
+    if (!category) fieldErrors.categoryId = "Select a valid, active category.";
+    if (!relatedSystem) fieldErrors.relatedSystemId = "Select a valid, active related system.";
+    if (Object.keys(fieldErrors).length > 0) {
+      res
+        .status(400)
+        .json({ error: "VALIDATION_FAILED", message: "Fix the highlighted fields.", fieldErrors });
+      return;
+    }
+
+    try {
+      const prisma = getPrisma();
+
+      // BR-01 — Ticket Number generated inside the same transaction as the
+      // insert, via the per-year TicketCounter row.
+      const ticket = await prisma.$transaction(async (tx) => {
+        const ticketNumber = await nextTicketNumber(tx);
+        return tx.ticket.create({
+          data: {
+            ticketNumber,
+            requesterId: req.requester!.id,
+            categoryId,
+            relatedSystemId,
+            summary,
+            description,
+            requestedPriority,
+          },
+        });
+      });
+
+      // BR-19 — attachment failures never roll back an already-created
+      // Ticket; each file succeeds or fails independently.
+      const files = (req.files as Express.Multer.File[] | undefined) ?? [];
+      const attachments: { id: number; originalFilename: string }[] = [];
+      const attachmentErrors: { originalFilename: string; reason: string; message: string }[] = [];
+
+      for (const file of files) {
+        const check = checkAttachmentFile(file.originalname, file.mimetype, file.size);
+        if (!check.ok) {
+          attachmentErrors.push({
+            originalFilename: file.originalname,
+            reason: check.reason,
+            message: check.message,
+          });
+          continue;
+        }
+
+        const storedFilename = generateStoredFilename(file.originalname);
+        try {
+          await saveAttachmentFile(storedFilename, file.buffer);
+          const attachment = await prisma.attachment.create({
+            data: {
+              ticketId: ticket.id,
+              originalFilename: file.originalname,
+              storedFilename,
+              mimeType: file.mimetype,
+              sizeBytes: file.size,
+              uploadedById: req.requester!.id,
+            },
+          });
+          attachments.push({ id: attachment.id, originalFilename: attachment.originalFilename });
+        } catch {
+          attachmentErrors.push({
+            originalFilename: file.originalname,
+            reason: "SAVE_FAILED",
+            message: "Could not save this file. You can add it again from Ticket Detail.",
+          });
+        }
+      }
+
+      res.status(201).json({
+        id: ticket.id,
+        ticketNumber: ticket.ticketNumber,
+        requesterId: ticket.requesterId,
+        summary: ticket.summary,
+        description: ticket.description,
+        categoryId: ticket.categoryId,
+        relatedSystemId: ticket.relatedSystemId,
+        requestedPriority: ticket.requestedPriority,
+        itPriority: ticket.itPriority,
+        currentStatus: ticket.currentStatus,
+        createdAt: ticket.createdAt,
+        updatedAt: ticket.updatedAt,
+        attachments,
+        attachmentErrors,
+      });
+    } catch {
+      res.status(500).json({ error: "INTERNAL_ERROR", message: "Something went wrong. Please try again." });
+    }
+  },
+);

--- a/server/tests/lab-02/attachment-rules.unit.test.ts
+++ b/server/tests/lab-02/attachment-rules.unit.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { checkAttachmentFile, generateStoredFilename, MAX_ATTACHMENT_BYTES } from "../../src/lib/attachmentRules.js";
+
+// UNIT-03, UNIT-04 in tests.md.
+describe("checkAttachmentFile", () => {
+  it("accepts jpg/jpeg/png/webp/pdf", () => {
+    expect(checkAttachmentFile("a.jpg", "image/jpeg", 100).ok).toBe(true);
+    expect(checkAttachmentFile("a.jpeg", "image/jpeg", 100).ok).toBe(true);
+    expect(checkAttachmentFile("a.png", "image/png", 100).ok).toBe(true);
+    expect(checkAttachmentFile("a.webp", "image/webp", 100).ok).toBe(true);
+    expect(checkAttachmentFile("a.pdf", "application/pdf", 100).ok).toBe(true);
+  });
+
+  it("rejects gif/exe/txt", () => {
+    expect(checkAttachmentFile("a.gif", "image/gif", 100).ok).toBe(false);
+    expect(checkAttachmentFile("a.exe", "application/octet-stream", 100).ok).toBe(false);
+    expect(checkAttachmentFile("a.txt", "text/plain", 100).ok).toBe(false);
+  });
+
+  it("rejects a mismatched extension/mimetype pair (BR-20: both must match)", () => {
+    const result = checkAttachmentFile("a.jpg", "application/pdf", 100);
+    expect(result.ok).toBe(false);
+  });
+
+  it("exactly 5MB passes; 5MB + 1 byte is rejected as SIZE", () => {
+    expect(checkAttachmentFile("a.jpg", "image/jpeg", MAX_ATTACHMENT_BYTES).ok).toBe(true);
+    const rejected = checkAttachmentFile("a.jpg", "image/jpeg", MAX_ATTACHMENT_BYTES + 1);
+    expect(rejected.ok).toBe(false);
+    if (!rejected.ok) expect(rejected.reason).toBe("SIZE");
+  });
+});
+
+// UNIT-05 in tests.md.
+describe("generateStoredFilename", () => {
+  it("output is a UUID + validated extension, never the original filename", () => {
+    const stored = generateStoredFilename("my secret resume.pdf");
+    expect(stored).not.toContain("secret");
+    expect(stored).not.toContain("resume");
+    expect(stored).toMatch(/^[0-9a-f-]{36}\.pdf$/);
+  });
+
+  it("two calls for the same original filename produce different stored names", () => {
+    const a = generateStoredFilename("photo.jpg");
+    const b = generateStoredFilename("photo.jpg");
+    expect(a).not.toBe(b);
+  });
+});

--- a/server/tests/lab-02/create-ticket.api.test.ts
+++ b/server/tests/lab-02/create-ticket.api.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import request from "supertest";
+import { app } from "../../src/app.js";
+import { getPrisma } from "../../src/prisma.js";
+import { seedAll } from "../../prisma/seed.js";
+
+// api-spec.md §4, specification.md BR-01..BR-04, BR-14..BR-19.
+describe("POST /api/tickets", () => {
+  let activeRequesterId: number;
+  let inactiveRequesterId: number;
+  let categoryId: number;
+  let relatedSystemId: number;
+
+  beforeAll(async () => {
+    await seedAll();
+    const prisma = getPrisma();
+    const activeRequester = await prisma.requesterUser.findFirstOrThrow({ where: { isActive: true } });
+    const inactiveRequester = await prisma.requesterUser.findFirstOrThrow({ where: { isActive: false } });
+    const category = await prisma.category.findFirstOrThrow({ where: { isActive: true } });
+    const relatedSystem = await prisma.relatedSystem.findFirstOrThrow({ where: { isActive: true } });
+    activeRequesterId = activeRequester.id;
+    inactiveRequesterId = inactiveRequester.id;
+    categoryId = category.id;
+    relatedSystemId = relatedSystem.id;
+  });
+
+  function validFields() {
+    return {
+      summary: "Laptop battery drains quickly",
+      description:
+        "The battery on my corporate laptop drains from full to empty within about two hours of normal use.",
+      categoryId: String(categoryId),
+      relatedSystemId: String(relatedSystemId),
+      requestedPriority: "MEDIUM",
+    };
+  }
+
+  // API-01
+  it("creates a Ticket with valid data and returns 201 with a Ticket Number", async () => {
+    const res = await request(app)
+      .post("/api/tickets")
+      .set("X-Dev-Requester-Id", String(activeRequesterId))
+      .field(validFields());
+
+    expect(res.status).toBe(201);
+    expect(res.body.ticketNumber).toMatch(/^TKT-\d{4}-\d{6}$/);
+    expect(res.body.currentStatus).toBe("NEW");
+
+    const saved = await getPrisma().ticket.findUnique({ where: { id: res.body.id } });
+    expect(saved).not.toBeNull();
+    expect(saved?.currentStatus).toBe("NEW");
+    expect(saved?.requesterId).toBe(activeRequesterId);
+  });
+
+  // API-02
+  it("rejects a missing summary with 400, a fieldErrors entry, and creates nothing", async () => {
+    const before = await getPrisma().ticket.count();
+    const fields = validFields();
+    const { summary: _drop, ...withoutSummary } = fields;
+
+    const res = await request(app)
+      .post("/api/tickets")
+      .set("X-Dev-Requester-Id", String(activeRequesterId))
+      .field(withoutSummary);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("VALIDATION_FAILED");
+    expect(res.body.fieldErrors).toHaveProperty("summary");
+
+    const after = await getPrisma().ticket.count();
+    expect(after).toBe(before);
+  });
+
+  // API-03
+  it("enforces the summary length boundary: 4 chars rejected, 5 accepted, 121 rejected, 120 accepted", async () => {
+    const tooShort = await request(app)
+      .post("/api/tickets")
+      .set("X-Dev-Requester-Id", String(activeRequesterId))
+      .field({ ...validFields(), summary: "abcd" });
+    expect(tooShort.status).toBe(400);
+
+    const minOk = await request(app)
+      .post("/api/tickets")
+      .set("X-Dev-Requester-Id", String(activeRequesterId))
+      .field({ ...validFields(), summary: "abcde" });
+    expect(minOk.status).toBe(201);
+
+    const tooLong = await request(app)
+      .post("/api/tickets")
+      .set("X-Dev-Requester-Id", String(activeRequesterId))
+      .field({ ...validFields(), summary: "a".repeat(121) });
+    expect(tooLong.status).toBe(400);
+
+    const maxOk = await request(app)
+      .post("/api/tickets")
+      .set("X-Dev-Requester-Id", String(activeRequesterId))
+      .field({ ...validFields(), summary: "a".repeat(120) });
+    expect(maxOk.status).toBe(201);
+  });
+
+  // API-04
+  it("rejects a categoryId referencing an inactive Category with 400", async () => {
+    const inactiveCategory = await getPrisma().category.create({
+      data: { name: `Deprecated ${Date.now()}`, isActive: false },
+    });
+
+    const res = await request(app)
+      .post("/api/tickets")
+      .set("X-Dev-Requester-Id", String(activeRequesterId))
+      .field({ ...validFields(), categoryId: String(inactiveCategory.id) });
+
+    expect(res.status).toBe(400);
+    expect(res.body.fieldErrors).toHaveProperty("categoryId");
+  });
+
+  // API-05
+  it("rejects an inactive Requester with 403", async () => {
+    const res = await request(app)
+      .post("/api/tickets")
+      .set("X-Dev-Requester-Id", String(inactiveRequesterId))
+      .field(validFields());
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("REQUESTER_INACTIVE");
+  });
+
+  it("rejects a missing X-Dev-Requester-Id header with 400", async () => {
+    const res = await request(app).post("/api/tickets").field(validFields());
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("MISSING_REQUESTER");
+  });
+
+  // API-06
+  it("still creates the Ticket when one of two attachments is oversized, reporting it in attachmentErrors", async () => {
+    const oversized = Buffer.alloc(6 * 1024 * 1024, 1); // 6MB > 5MB limit
+    const validImage = Buffer.from([0xff, 0xd8, 0xff, 0xdb, 0x00, 0x84]);
+
+    const res = await request(app)
+      .post("/api/tickets")
+      .set("X-Dev-Requester-Id", String(activeRequesterId))
+      .field(validFields())
+      .attach("attachments", validImage, { filename: "photo.jpg", contentType: "image/jpeg" })
+      .attach("attachments", oversized, { filename: "huge.jpg", contentType: "image/jpeg" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.attachments).toHaveLength(1);
+    expect(res.body.attachments[0].originalFilename).toBe("photo.jpg");
+    expect(res.body.attachmentErrors).toHaveLength(1);
+    expect(res.body.attachmentErrors[0].originalFilename).toBe("huge.jpg");
+    expect(res.body.attachmentErrors[0].reason).toBe("SIZE");
+
+    const saved = await getPrisma().ticket.findUnique({ where: { id: res.body.id } });
+    expect(saved).not.toBeNull();
+  });
+});

--- a/server/tests/lab-02/ticket-number.unit.test.ts
+++ b/server/tests/lab-02/ticket-number.unit.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { getPrisma } from "../../src/prisma.js";
+import { nextTicketNumber } from "../../src/lib/ticketNumber.js";
+
+// UNIT-01, UNIT-02 in tests.md.
+describe("nextTicketNumber", () => {
+  it("matches TKT-YYYY-NNNNNN with the correct year", async () => {
+    const number = await getPrisma().$transaction((tx) =>
+      nextTicketNumber(tx, new Date("2026-06-01T00:00:00Z")),
+    );
+    expect(number).toMatch(/^TKT-2026-\d{6}$/);
+  });
+
+  it("20 concurrent generations in the same year are all unique", async () => {
+    const prisma = getPrisma();
+    const results = await Promise.all(
+      Array.from({ length: 20 }, () =>
+        prisma.$transaction((tx) => nextTicketNumber(tx, new Date("2027-01-01T00:00:00Z"))),
+      ),
+    );
+    expect(new Set(results).size).toBe(20);
+  });
+});


### PR DESCRIPTION
## Summary
Implements `POST /api/tickets` per `api-spec.md` §4: transactional Ticket Number generation, field validation, and inline attachment handling on the same multipart request.

## Details
- `lib/ticketNumber.ts`: BR-01 — `TKT-YYYY-NNNNNN`, generated via an atomic per-year `TicketCounter` upsert(increment) inside the same transaction as the Ticket insert. Race-safe under concurrency (tested with 20 parallel calls).
- `lib/ticketValidation.ts`: BR-14/15 field validation (summary 5-120, description 20-4000, active category/related-system, valid priority).
- `lib/attachmentRules.ts` + `attachmentStorage.ts`: BR-20/21/25 — type (extension + mimetype) and size checks, UUID-named disk storage. Shared helpers, reused by Issue 31's standalone attachment endpoints.
- `middleware/requesterAuth.ts`: resolves `X-Dev-Requester-Id` per api-spec.md §0 (400 missing/unknown, 403 inactive).
- BR-19: an invalid attachment (oversized/wrong type) never blocks Ticket creation — the Ticket still gets its number, the bad file is reported in `attachmentErrors`.

## Note for review
This branch and #24 both branched from `lab2-staging` before either merged (independent, parallel Issues per the Wave 3 plan), so both touch `server/src/app.ts`. Whichever merges second will need a quick rebase — I'll handle that when the time comes.

## Test evidence
`cd server && npm test` — 6 files, 21 tests passing (2 Lab 1 + 19 Lab 2). UNIT-01..05 and API-01..06 now Pass in tests.md.

Resolves #26

Note: this PR targets `lab2-staging`, not the default branch, so the keyword above shows as a mention only. Link it to Issue 26 manually via the Development panel per the TokTickIT GitHub Workflow Guide.