### PR TITLE
Issue 27: Create Ticket screen

### DIFF
--- a/client/src/api/reference.ts
+++ b/client/src/api/reference.ts
@@ -1,0 +1,24 @@
+const API_URL = import.meta.env.VITE_API_URL ?? "http://localhost:3000";
+
+export interface Category {
+  id: number;
+  name: string;
+}
+
+export interface RelatedSystem {
+  id: number;
+  name: string;
+}
+
+// Issue 27 — reference data for the Create Ticket dropdowns (api-spec.md §1-2).
+export async function fetchCategories(): Promise<Category[]> {
+  const res = await fetch(`${API_URL}/api/categories`);
+  if (!res.ok) throw new Error("Unable to load categories.");
+  return res.json();
+}
+
+export async function fetchRelatedSystems(): Promise<RelatedSystem[]> {
+  const res = await fetch(`${API_URL}/api/related-systems`);
+  if (!res.ok) throw new Error("Unable to load related systems.");
+  return res.json();
+}

--- a/client/src/api/tickets.ts
+++ b/client/src/api/tickets.ts
@@ -1,0 +1,74 @@
+const API_URL = import.meta.env.VITE_API_URL ?? "http://localhost:3000";
+
+export interface CreateTicketResult {
+  id: number;
+  ticketNumber: string;
+  requesterId: number;
+  summary: string;
+  description: string;
+  categoryId: number;
+  relatedSystemId: number;
+  requestedPriority: string;
+  itPriority: string | null;
+  currentStatus: string;
+  createdAt: string;
+  updatedAt: string;
+  attachments: { id: number; originalFilename: string }[];
+  attachmentErrors: { originalFilename: string; reason: string; message: string }[];
+}
+
+// Thrown on a 400 VALIDATION_FAILED response so callers can tell "your
+// input was rejected" apart from "the request itself failed" (BR-17/AC-04).
+export class ValidationError extends Error {
+  fieldErrors: Record<string, string>;
+  constructor(fieldErrors: Record<string, string>) {
+    super("Validation failed");
+    this.fieldErrors = fieldErrors;
+  }
+}
+
+export interface CreateTicketInput {
+  requesterId: number;
+  summary: string;
+  description: string;
+  categoryId: string;
+  relatedSystemId: string;
+  requestedPriority: string;
+  files: File[];
+}
+
+// Issue 27 — POST /api/tickets (api-spec.md §4). multipart/form-data with
+// the Requester identity on X-Dev-Requester-Id, per api-spec.md §0.
+export async function createTicket(input: CreateTicketInput): Promise<CreateTicketResult> {
+  const formData = new FormData();
+  formData.append("summary", input.summary);
+  formData.append("description", input.description);
+  formData.append("categoryId", input.categoryId);
+  formData.append("relatedSystemId", input.relatedSystemId);
+  formData.append("requestedPriority", input.requestedPriority);
+  for (const file of input.files) {
+    formData.append("attachments", file);
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(`${API_URL}/api/tickets`, {
+      method: "POST",
+      headers: { "X-Dev-Requester-Id": String(input.requesterId) },
+      body: formData,
+    });
+  } catch {
+    throw new Error("Unable to connect to TokTickIT API. Please try again.");
+  }
+
+  if (res.status === 400) {
+    const body = await res.json().catch(() => ({}));
+    throw new ValidationError(body.fieldErrors ?? {});
+  }
+
+  if (!res.ok) {
+    throw new Error("Unable to create the ticket. Please try again.");
+  }
+
+  return res.json();
+}

--- a/client/src/lib/attachmentRules.ts
+++ b/client/src/lib/attachmentRules.ts
@@ -1,0 +1,24 @@
+// Issue 27 — client-side mirror of server/src/lib/attachmentRules.ts
+// (BR-20/BR-21). Rejects an obviously invalid file before it is ever sent,
+// per AC-07; the backend re-checks everything regardless (BR-17).
+export const MAX_ATTACHMENT_BYTES = 5 * 1024 * 1024;
+export const MAX_ACTIVE_ATTACHMENTS = 5;
+
+const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp", "application/pdf"];
+const ALLOWED_EXTENSIONS = [".jpg", ".jpeg", ".png", ".webp", ".pdf"];
+
+export function checkAttachmentFile(file: File): { ok: true } | { ok: false; message: string } {
+  if (file.size > MAX_ATTACHMENT_BYTES) {
+    return { ok: false, message: `${file.name} exceeds the 5MB limit.` };
+  }
+
+  const lowerName = file.name.toLowerCase();
+  const hasAllowedExtension = ALLOWED_EXTENSIONS.some((ext) => lowerName.endsWith(ext));
+  const hasAllowedType = ALLOWED_TYPES.includes(file.type);
+
+  if (!hasAllowedExtension || !hasAllowedType) {
+    return { ok: false, message: `${file.name} is not a permitted file type (JPG, PNG, WEBP, or PDF only).` };
+  }
+
+  return { ok: true };
+}

--- a/client/src/pages/CreateTicketPage.tsx
+++ b/client/src/pages/CreateTicketPage.tsx
@@ -1,10 +1,333 @@
-// Placeholder route target for Issue 23's router skeleton.
-// Real implementation is Issue 27 — see docs/lab-02/ui-spec.md §6.
+import { ChangeEvent, FormEvent, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { useRequester } from "../context/RequesterContext.js";
+import { fetchCategories, fetchRelatedSystems, Category, RelatedSystem } from "../api/reference.js";
+import { createTicket, CreateTicketResult, ValidationError } from "../api/tickets.js";
+import { checkAttachmentFile, MAX_ACTIVE_ATTACHMENTS } from "../lib/attachmentRules.js";
+import { TextField } from "../components/ui/TextField.js";
+import { TextArea } from "../components/ui/TextArea.js";
+import { Select } from "../components/ui/Select.js";
+import { Button } from "../components/ui/Button.js";
+import { Alert } from "../components/ui/Alert.js";
+import { Spinner } from "../components/ui/Spinner.js";
+
+const PRIORITY_OPTIONS = [
+  { value: "LOW", label: "Low" },
+  { value: "MEDIUM", label: "Medium" },
+  { value: "HIGH", label: "High" },
+  { value: "URGENT", label: "Urgent" },
+];
+
+type ReferenceState = "loading" | "loaded" | "error";
+
+// Issue 27 — Create Ticket screen (ui-spec.md §6). System-generated fields
+// near the top (read-only), classification fields grouped, Summary/
+// Description given room, Attachments below, primary/secondary actions at
+// the bottom.
 export function CreateTicketPage() {
+  const { requester } = useRequester();
+
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [relatedSystems, setRelatedSystems] = useState<RelatedSystem[]>([]);
+  const [referenceState, setReferenceState] = useState<ReferenceState>("loading");
+
+  const [summary, setSummary] = useState("");
+  const [description, setDescription] = useState("");
+  const [categoryId, setCategoryId] = useState("");
+  const [relatedSystemId, setRelatedSystemId] = useState("");
+  const [requestedPriority, setRequestedPriority] = useState("");
+  const [files, setFiles] = useState<File[]>([]);
+  const [attachmentPickerErrors, setAttachmentPickerErrors] = useState<string[]>([]);
+
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [result, setResult] = useState<CreateTicketResult | null>(null);
+
+  useEffect(() => {
+    setReferenceState("loading");
+    Promise.all([fetchCategories(), fetchRelatedSystems()])
+      .then(([cats, systems]) => {
+        setCategories(cats);
+        setRelatedSystems(systems);
+        setReferenceState("loaded");
+      })
+      .catch(() => setReferenceState("error"));
+  }, []);
+
+  function handleFilesSelected(e: ChangeEvent<HTMLInputElement>) {
+    const picked = Array.from(e.target.files ?? []);
+    e.target.value = ""; // allow re-selecting a file with the same name later
+
+    const errors: string[] = [];
+    const accepted: File[] = [];
+
+    for (const file of picked) {
+      if (files.length + accepted.length >= MAX_ACTIVE_ATTACHMENTS) {
+        errors.push(`${file.name} was not added: a Ticket allows at most ${MAX_ACTIVE_ATTACHMENTS} attachments.`);
+        continue;
+      }
+      const check = checkAttachmentFile(file);
+      if (!check.ok) {
+        errors.push(check.message);
+        continue;
+      }
+      accepted.push(file);
+    }
+
+    if (accepted.length > 0) setFiles((prev) => [...prev, ...accepted]);
+    setAttachmentPickerErrors(errors);
+  }
+
+  function removeFile(index: number) {
+    setFiles((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  function validate(): Record<string, string> {
+    const errors: Record<string, string> = {};
+    const trimmedSummary = summary.trim();
+    if (trimmedSummary.length < 5 || trimmedSummary.length > 120) {
+      errors.summary = "Summary must be 5-120 characters.";
+    }
+    const trimmedDescription = description.trim();
+    if (trimmedDescription.length < 20 || trimmedDescription.length > 4000) {
+      errors.description = "Description must be 20-4000 characters.";
+    }
+    if (!categoryId) errors.categoryId = "Select a category.";
+    if (!relatedSystemId) errors.relatedSystemId = "Select a related system.";
+    if (!requestedPriority) errors.requestedPriority = "Select a requested priority.";
+    return errors;
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!requester) return;
+
+    const errors = validate();
+    setFieldErrors(errors);
+    if (Object.keys(errors).length > 0) return; // AC-04 — no request sent on client-side validation failure
+
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      const created = await createTicket({
+        requesterId: requester.id,
+        summary,
+        description,
+        categoryId,
+        relatedSystemId,
+        requestedPriority,
+        files,
+      });
+      setResult(created);
+    } catch (err) {
+      if (err instanceof ValidationError) {
+        setFieldErrors(err.fieldErrors); // BR-18 — entered values are untouched either way
+      } else {
+        setSubmitError(err instanceof Error ? err.message : "Unable to create the ticket. Please try again.");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function resetForm() {
+    setSummary("");
+    setDescription("");
+    setCategoryId("");
+    setRelatedSystemId("");
+    setRequestedPriority("");
+    setFiles([]);
+    setAttachmentPickerErrors([]);
+    setFieldErrors({});
+    setSubmitError(null);
+    setResult(null);
+  }
+
+  if (result) {
+    return (
+      <div style={{ display: "flex", flexDirection: "column", gap: "var(--zen-space-4)", maxWidth: 560 }}>
+        <Alert tone="success">
+          <p style={{ margin: 0 }}>Ticket created. Your Ticket Number is:</p>
+          <p style={{ margin: "4px 0 0", fontSize: "var(--zen-fs-h1)", fontWeight: 700 }}>
+            {result.ticketNumber}
+          </p>
+        </Alert>
+
+        {result.attachmentErrors.length > 0 && (
+          <Alert tone="warning">
+            {result.attachmentErrors.length} attachment(s) could not be added (
+            {result.attachmentErrors.map((a) => a.originalFilename).join(", ")}). You can add them
+            again from Ticket Detail.
+          </Alert>
+        )}
+
+        <div style={{ display: "flex", gap: "var(--zen-space-3)" }}>
+          <Link to={`/tickets/${result.id}`} className="zen-btn zen-btn-primary">
+            View Ticket
+          </Link>
+          <Button variant="tertiary" onClick={resetForm}>
+            Create Another
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div>
+    <form onSubmit={handleSubmit} style={{ maxWidth: 720 }} noValidate>
       <h1 style={{ fontSize: "var(--zen-fs-h1)" }}>Create Ticket</h1>
-      <p>Implemented in Issue 27.</p>
-    </div>
+
+      {submitError && <Alert tone="error">{submitError}</Alert>}
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+          gap: "var(--zen-space-3)",
+        }}
+      >
+        <TextField
+          label="Ticket Number"
+          readOnly
+          value="(assigned after submission)"
+          readOnlyReason="System-generated after you submit."
+        />
+        <TextField
+          label="Ticket Date"
+          readOnly
+          value="(set on submission)"
+          readOnlyReason="System-generated after you submit."
+        />
+        <TextField
+          label="Requester"
+          readOnly
+          value={requester?.fullName ?? ""}
+          readOnlyReason="From your Development Requester selection."
+        />
+      </div>
+
+      {referenceState === "loading" && <Spinner label="Loading categories and related systems…" />}
+      {referenceState === "error" && (
+        <Alert tone="error">Unable to load categories and related systems. Please reload the page.</Alert>
+      )}
+
+      {referenceState === "loaded" && (
+        <>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
+              gap: "var(--zen-space-3)",
+            }}
+          >
+            <Select
+              label="Category"
+              required
+              value={categoryId}
+              onChange={(e) => setCategoryId(e.target.value)}
+              placeholder="Select a category"
+              error={fieldErrors.categoryId}
+              options={categories.map((c) => ({ value: String(c.id), label: c.name }))}
+              disabled={submitting}
+            />
+            <Select
+              label="Related System"
+              required
+              value={relatedSystemId}
+              onChange={(e) => setRelatedSystemId(e.target.value)}
+              placeholder="Select a related system"
+              error={fieldErrors.relatedSystemId}
+              options={relatedSystems.map((s) => ({ value: String(s.id), label: s.name }))}
+              disabled={submitting}
+            />
+            <Select
+              label="Requested Priority"
+              required
+              value={requestedPriority}
+              onChange={(e) => setRequestedPriority(e.target.value)}
+              placeholder="Select a priority"
+              error={fieldErrors.requestedPriority}
+              options={PRIORITY_OPTIONS}
+              disabled={submitting}
+            />
+          </div>
+
+          <TextField
+            label="Ticket Summary"
+            required
+            value={summary}
+            onChange={(e) => setSummary(e.target.value)}
+            error={fieldErrors.summary}
+            caption={`${summary.length}/120`}
+            disabled={submitting}
+          />
+
+          <TextArea
+            label="Description"
+            required
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            error={fieldErrors.description}
+            caption={`${description.length}/4000`}
+            disabled={submitting}
+          />
+
+          <div className="zen-field">
+            <label className="zen-field-label" htmlFor="attachments-input">
+              Attachments
+            </label>
+            <p className="zen-field-caption">
+              JPG, PNG, WEBP, or PDF. Max 5MB each, up to {MAX_ACTIVE_ATTACHMENTS} files. {files.length}/
+              {MAX_ACTIVE_ATTACHMENTS} attached.
+            </p>
+            <input
+              id="attachments-input"
+              type="file"
+              multiple
+              accept=".jpg,.jpeg,.png,.webp,.pdf"
+              onChange={handleFilesSelected}
+              disabled={submitting || files.length >= MAX_ACTIVE_ATTACHMENTS}
+            />
+            {attachmentPickerErrors.map((msg, i) => (
+              <p key={i} className="zen-field-error" role="alert">
+                {msg}
+              </p>
+            ))}
+            {files.length > 0 && (
+              <ul style={{ listStyle: "none", padding: 0, margin: "var(--zen-space-2) 0 0" }}>
+                {files.map((file, i) => (
+                  <li
+                    key={`${file.name}-${i}`}
+                    style={{ display: "flex", alignItems: "center", gap: "var(--zen-space-2)" }}
+                  >
+                    <span>{file.name}</span>
+                    <button
+                      type="button"
+                      className="zen-btn zen-btn-tertiary"
+                      aria-label={`Remove ${file.name}`}
+                      title={`Remove ${file.name}`}
+                      onClick={() => removeFile(i)}
+                      disabled={submitting}
+                    >
+                      Remove
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          <div style={{ display: "flex", gap: "var(--zen-space-3)", marginTop: "var(--zen-space-4)" }}>
+            <Button type="submit" variant="primary" busy={submitting} busyText="Submitting…">
+              Submit Ticket
+            </Button>
+            <Button type="button" variant="tertiary" onClick={resetForm} disabled={submitting}>
+              Cancel
+            </Button>
+          </div>
+        </>
+      )}
+    </form>
   );
 }

--- a/client/tests/lab-02/CreateTicket.test.tsx
+++ b/client/tests/lab-02/CreateTicket.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { http, HttpResponse, delay } from "msw";
+import { server } from "../msw/server.js";
+import { RequesterProvider } from "../../src/context/RequesterContext.js";
+import { CreateTicketPage } from "../../src/pages/CreateTicketPage.js";
+
+const API_URL = "http://localhost:3000";
+
+function renderPage() {
+  sessionStorage.setItem(
+    "toktickit:lab2:selectedRequester",
+    JSON.stringify({ id: 1, fullName: "Aran Suksawat" }),
+  );
+  return render(
+    <MemoryRouter>
+      <RequesterProvider>
+        <CreateTicketPage />
+      </RequesterProvider>
+    </MemoryRouter>,
+  );
+}
+
+async function fillValidForm(user: ReturnType<typeof userEvent.setup>) {
+  await screen.findByLabelText(/category/i); // wait for reference data to load
+  await user.type(screen.getByLabelText(/ticket summary/i), "Laptop battery drains quickly");
+  await user.type(
+    screen.getByLabelText(/description/i),
+    "The battery on my corporate laptop drains from full to empty within about two hours.",
+  );
+  await user.selectOptions(screen.getByLabelText(/category/i), "2");
+  await user.selectOptions(screen.getByLabelText(/related system/i), "2");
+  await user.selectOptions(screen.getByLabelText(/requested priority/i), "MEDIUM");
+}
+
+describe("Create Ticket screen", () => {
+  afterEach(() => {
+    sessionStorage.clear();
+  });
+
+  // UI-04
+  it("shows a field-level message and sends no request when Summary is empty", async () => {
+    const user = userEvent.setup();
+    let submitCalled = false;
+    server.use(
+      http.post(`${API_URL}/api/tickets`, () => {
+        submitCalled = true;
+        return HttpResponse.json({}, { status: 201 });
+      }),
+    );
+
+    renderPage();
+    await screen.findByLabelText(/category/i);
+    await user.click(screen.getByRole("button", { name: /submit ticket/i }));
+
+    expect(await screen.findByText(/summary must be 5-120 characters/i)).toBeInTheDocument();
+    expect(submitCalled).toBe(false);
+  });
+
+  // UI-05
+  it("shows a failure banner and keeps every entered value when the request fails", async () => {
+    server.use(http.post(`${API_URL}/api/tickets`, () => HttpResponse.error()));
+
+    const user = userEvent.setup();
+    renderPage();
+    await fillValidForm(user);
+    await user.click(screen.getByRole("button", { name: /submit ticket/i }));
+
+    expect(await screen.findByText(/unable to connect to toktickit api/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/ticket summary/i)).toHaveValue("Laptop battery drains quickly");
+    expect(screen.getByLabelText(/category/i)).toHaveValue("2");
+  });
+
+  // UI-06
+  it("shows a busy state on Submit and disables it while the request is in flight", async () => {
+    server.use(
+      http.post(`${API_URL}/api/tickets`, async () => {
+        await delay(50);
+        return HttpResponse.json(
+          {
+            id: 1,
+            ticketNumber: "TKT-2026-000001",
+            attachments: [],
+            attachmentErrors: [],
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderPage();
+    await fillValidForm(user);
+    await user.click(screen.getByRole("button", { name: /submit ticket/i }));
+
+    expect(screen.getByRole("button", { name: /submitting/i })).toBeDisabled();
+    await waitFor(() => expect(screen.getByText("TKT-2026-000001")).toBeInTheDocument());
+  });
+
+  // UI-07
+  it("shows the confirmation panel with the generated Ticket Number on success", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await fillValidForm(user);
+    await user.click(screen.getByRole("button", { name: /submit ticket/i }));
+
+    expect(await screen.findByText("TKT-2026-000042")).toBeInTheDocument();
+  });
+
+  // UI-08
+  it("rejects an oversized file client-side before any request is sent", async () => {
+    let uploadAttempted = false;
+    server.use(
+      http.post(`${API_URL}/api/tickets`, () => {
+        uploadAttempted = true;
+        return HttpResponse.json({}, { status: 201 });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByLabelText(/category/i);
+
+    const oversized = new File([new Uint8Array(6 * 1024 * 1024)], "huge.jpg", { type: "image/jpeg" });
+    const input = document.getElementById("attachments-input") as HTMLInputElement;
+    await user.upload(input, oversized);
+
+    expect(await screen.findByText(/huge\.jpg exceeds the 5mb limit/i)).toBeInTheDocument();
+    expect(screen.queryByText("huge.jpg")).not.toBeInTheDocument(); // not added to the selected-files list
+    expect(uploadAttempted).toBe(false);
+  });
+});

--- a/client/tests/msw/handlers.ts
+++ b/client/tests/msw/handlers.ts
@@ -3,13 +3,47 @@ import { http, HttpResponse } from "msw";
 const API_URL = "http://localhost:3000";
 
 // Default handlers — individual tests override these with server.use(...)
-// for empty/failure/etc. states. Issue 25 covers /api/dev-requesters only;
-// later issues add handlers for tickets/attachments here.
+// for empty/failure/etc. states.
 export const handlers = [
   http.get(`${API_URL}/api/dev-requesters`, () =>
     HttpResponse.json([
       { id: 1, fullName: "Aran Suksawat", email: "aran.suksawat@example.dev" },
       { id: 2, fullName: "Buppha Ratanakorn", email: "buppha.ratanakorn@example.dev" },
     ]),
+  ),
+
+  // Issue 27
+  http.get(`${API_URL}/api/categories`, () =>
+    HttpResponse.json([
+      { id: 1, name: "Account and Access" },
+      { id: 2, name: "Hardware" },
+    ]),
+  ),
+  http.get(`${API_URL}/api/related-systems`, () =>
+    HttpResponse.json([
+      { id: 1, name: "Email" },
+      { id: 2, name: "Corporate Laptop" },
+    ]),
+  ),
+  http.post(`${API_URL}/api/tickets`, () =>
+    HttpResponse.json(
+      {
+        id: 42,
+        ticketNumber: "TKT-2026-000042",
+        requesterId: 1,
+        summary: "Laptop battery drains quickly",
+        description: "The battery on my corporate laptop drains quickly.",
+        categoryId: 2,
+        relatedSystemId: 2,
+        requestedPriority: "MEDIUM",
+        itPriority: null,
+        currentStatus: "NEW",
+        createdAt: "2026-08-24T10:15:00.000Z",
+        updatedAt: "2026-08-24T10:15:00.000Z",
+        attachments: [],
+        attachmentErrors: [],
+      },
+      { status: 201 },
+    ),
   ),
 ];

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -47,11 +47,11 @@ Criterion in `specification.md` §9 maps to at least one row below.
 | UI-01 | UI component | AC-02 | Visiting `/tickets` with no Requester selected | Redirected to `/select-requester` | `client/tests/lab-02/RequesterSelect.test.tsx` | **Pass** |
 | UI-02 | UI component | AC-16 | Requester Selection screen, mocked empty active-Requester list | Empty-state message shown; dropdown and Continue are not rendered at all (not merely disabled) | `client/tests/lab-02/RequesterSelect.test.tsx` | **Pass** |
 | UI-03 | UI component | AC-15 | Requester Selection screen, mocked API failure | Failure callout + Retry button shown | `client/tests/lab-02/RequesterSelect.test.tsx` | **Pass** |
-| UI-04 | UI component | AC-04 | Create Ticket submitted with empty `summary` | Field-level message renders under Summary; no POST fired | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
-| UI-05 | UI component | AC-05, BR-18 | Create Ticket submit, mocked network failure | Failure banner shown; all typed field values still present | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
-| UI-06 | UI component | §6 (Submitting state) | Click Submit with a slow mocked response | Button shows busy state and is disabled for the duration | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
-| UI-07 | UI component | AC-01 | Create Ticket submit, mocked success | Confirmation panel shows the returned Ticket Number | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
-| UI-08 | UI component | AC-07 | Select an 8MB file in the attachment picker | Rejected client-side before any request; message names the size limit | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
+| UI-04 | UI component | AC-04 | Create Ticket submitted with empty `summary` | Field-level message renders under Summary; no POST fired | `client/tests/lab-02/CreateTicket.test.tsx` | **Pass** |
+| UI-05 | UI component | AC-05, BR-18 | Create Ticket submit, mocked network failure | Failure banner shown; all typed field values still present | `client/tests/lab-02/CreateTicket.test.tsx` | **Pass** |
+| UI-06 | UI component | §6 (Submitting state) | Click Submit with a slow mocked response | Button shows busy state and is disabled for the duration | `client/tests/lab-02/CreateTicket.test.tsx` | **Pass** |
+| UI-07 | UI component | AC-01 | Create Ticket submit, mocked success | Confirmation panel shows the returned Ticket Number | `client/tests/lab-02/CreateTicket.test.tsx` | **Pass** |
+| UI-08 | UI component | AC-07 | Select an 8MB file in the attachment picker | Rejected client-side before any request; message names the size limit | `client/tests/lab-02/CreateTicket.test.tsx` | **Pass** |
 | UI-09 | UI component | AC-11 vs AC-12 | My Tickets: mocked 0-tickets-ever vs. mocked 0-matches-with-filter | Distinct empty-state and no-results copy render for each case | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
 | UI-10 | UI component | AC-10 | My Tickets rendered, then Requester context switched | List refetches and old Requester's rows are gone | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
 | UI-11 | UI component | §7 (pagination) | Change page-size control | Triggers a refetch with the new `pageSize`; page resets to 1 | `client/tests/lab-02/MyTickets.test.tsx` | Planned |


### PR DESCRIPTION
## Summary
Real Create Ticket screen per `ui-spec.md` §6, replacing the Issue 23 placeholder: system-generated fields, classification group, Summary/Description, attachment picker, and initial/validation/submitting/success/failure states.

## Details
- `api/reference.ts`, `api/tickets.ts`: GET categories/related-systems, POST /api/tickets (multipart, `X-Dev-Requester-Id` header, distinguishes `ValidationError` from network/server failure)
- `lib/attachmentRules.ts`: client-side mirror of the server's type/size checks (AC-07) — a bad file is rejected before any request
- BR-18: every entered field value survives a failed submission; only Cancel/Create Another clears the form
- BR-19: a partial attachment-upload failure shows as a warning on the success panel (Ticket still created), not a failure state

## Test evidence
`cd client && npm test` — 4 files, 19 tests passing (3 Lab 1 + 16 Lab 2). UI-04..UI-08 now Pass in tests.md. `npm run build` clean.

Resolves #27

Note: this PR targets `lab2-staging`, not the default branch, so the keyword above shows as a mention only. Link it to Issue 27 manually via the Development panel per the TokTickIT GitHub Workflow Guide.