### PR TITLE
Issue 28: My Tickets list API

### DIFF
--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -28,11 +28,11 @@ Criterion in `specification.md` §9 maps to at least one row below.
 | API-04 | API | BR-15 | `categoryId` referencing an inactive Category | `400` | `server/tests/lab-02/create-ticket.api.test.ts` | **Pass** |
 | API-05 | API | §0, BR-26 | Request with inactive Requester header | `403` | `server/tests/lab-02/create-ticket.api.test.ts` | **Pass** |
 | API-06 | API | BR-19 | Create with one valid + one oversized attachment | `201`; ticket saved; `attachmentErrors` lists the oversized file | `server/tests/lab-02/create-ticket.api.test.ts` | **Pass** |
-| API-07 | API | AC-10, BR-09 | `GET /api/tickets` as Requester A vs Requester B | Each sees only their own tickets | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
-| API-08 | API | BR-11 | `search=` matching a `ticketNumber` and separately a `summary` substring | Both return the matching ticket; unrelated tickets excluded | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
-| API-09 | API | BR-12 | Two tickets with identical `createdAt`, sorted by `createdAt:desc` twice | Row order identical both times (secondary `id:desc` holds) | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
-| API-10 | API | AC-13, BR-13 | `pageSize=7` and `page=999` | Both `400`, naming the invalid parameter | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
-| API-11 | API | AC-11, AC-12 | List with 0 tickets ever vs. 0 tickets matching an active filter | `meta.appliedFilters` distinguishes the two cases correctly | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
+| API-07 | API | AC-10, BR-09 | `GET /api/tickets` as Requester A vs Requester B | Each sees only their own tickets | `server/tests/lab-02/my-tickets.api.test.ts` | **Pass** |
+| API-08 | API | BR-11 | `search=` matching a `ticketNumber` and separately a `summary` substring | Both return the matching ticket; unrelated tickets excluded | `server/tests/lab-02/my-tickets.api.test.ts` | **Pass** |
+| API-09 | API | BR-12 | Two tickets with identical `createdAt`, sorted by `createdAt:desc` twice | Row order identical both times (secondary `id:desc` holds) | `server/tests/lab-02/my-tickets.api.test.ts` | **Pass** |
+| API-10 | API | AC-13, BR-13 | `pageSize=7` and `page=999` | Both `400`, naming the invalid parameter | `server/tests/lab-02/my-tickets.api.test.ts` | **Pass** |
+| API-11 | API | AC-11, AC-12 | List with 0 tickets ever vs. 0 tickets matching an active filter | `meta.appliedFilters` distinguishes the two cases correctly | `server/tests/lab-02/my-tickets.api.test.ts` | **Pass** |
 | API-12 | API | AC-03, BR-10 | `GET /api/tickets/:id` for another Requester's ticket | `404`, identical body to a nonexistent id | `server/tests/lab-02/ticket-detail.api.test.ts` | Planned |
 | API-13 | API | FR-05 | `GET /api/tickets/:id` for own ticket | `200`; includes nested `attachments` array | `server/tests/lab-02/ticket-detail.api.test.ts` | Planned |
 | API-14 | API | AC-06, BR-21 | `POST .../attachments` on a ticket that already has 5 active attachments | `409 ATTACHMENT_LIMIT_REACHED`; count stays 5 | `server/tests/lab-02/attachments.api.test.ts` | Planned |

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -2,6 +2,7 @@ import express, { Request, Response } from "express";
 import cors from "cors";
 import { referenceRouter } from "./routes/reference.js";
 import { ticketsRouter } from "./routes/tickets.js";
+import { myTicketsRouter } from "./routes/myTickets.js";
 
 // The Express app is exported separately from app.listen() (see index.ts) so
 // Supertest can import `app` without opening a port. Do not merge these files.
@@ -25,5 +26,8 @@ app.use(referenceRouter);
 
 // Issue 26 — POST /api/tickets. See routes/tickets.ts.
 app.use(ticketsRouter);
+
+// Issue 28 — GET /api/tickets (paginated, owned list). See routes/myTickets.ts.
+app.use(myTicketsRouter);
 
 export default app;

--- a/server/src/routes/myTickets.ts
+++ b/server/src/routes/myTickets.ts
@@ -1,0 +1,172 @@
+import { Router, Request, Response } from "express";
+import { Prisma } from "@prisma/client";
+import { getPrisma } from "../prisma.js";
+import { requesterAuth } from "../middleware/requesterAuth.js";
+import { PRIORITIES } from "../lib/ticketValidation.js";
+
+// Issue 28 — GET /api/tickets (api-spec.md §5). Every result is scoped to
+// the requesting Requester (BR-09); search/filter/sort/pagination are all
+// query-driven and every invalid value returns 400 naming the parameter
+// (BR-13) rather than silently clamping or ignoring it.
+export const myTicketsRouter = Router();
+
+const SORT_FIELDS = ["createdAt", "updatedAt", "ticketNumber", "requestedPriority"] as const;
+type SortField = (typeof SORT_FIELDS)[number];
+const PAGE_SIZES = [10, 20, 50] as const;
+const STATUSES = ["NEW"] as const; // only status reachable in Lab 2
+
+function invalidQuery(res: Response, field: string, message: string) {
+  res.status(400).json({ error: "INVALID_QUERY", message, fieldErrors: { [field]: message } });
+}
+
+function parsePositiveInt(raw: unknown): number | null {
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+myTicketsRouter.get("/api/tickets", requesterAuth, async (req: Request, res: Response) => {
+  const q = req.query;
+  const prisma = getPrisma();
+
+  // pageSize — 10 | 20 | 50 only (BR-13)
+  let pageSize = 10;
+  if (q.pageSize !== undefined) {
+    const n = Number(q.pageSize);
+    if (!(PAGE_SIZES as readonly number[]).includes(n)) {
+      invalidQuery(res, "pageSize", "pageSize must be 10, 20, or 50.");
+      return;
+    }
+    pageSize = n;
+  }
+
+  // sort — field[:asc|desc], default createdAt:desc (BR-12)
+  let sortField: SortField = "createdAt";
+  let sortDir: "asc" | "desc" = "desc";
+  if (q.sort !== undefined) {
+    const [field, dir] = String(q.sort).split(":");
+    if (!(SORT_FIELDS as readonly string[]).includes(field) || (dir && dir !== "asc" && dir !== "desc")) {
+      invalidQuery(
+        res,
+        "sort",
+        "sort must be one of createdAt, updatedAt, ticketNumber, requestedPriority, optionally suffixed :asc or :desc.",
+      );
+      return;
+    }
+    sortField = field as SortField;
+    sortDir = (dir as "asc" | "desc") ?? "desc";
+  }
+
+  // filters — always scoped to the requesting Requester (BR-09)
+  const where: Prisma.TicketWhereInput = { requesterId: req.requester!.id };
+  const appliedFilters: Record<string, string | number | null> = {
+    search: null,
+    categoryId: null,
+    relatedSystemId: null,
+    requestedPriority: null,
+    status: null,
+  };
+
+  if (q.search !== undefined) {
+    const search = String(q.search);
+    where.OR = [
+      { ticketNumber: { contains: search, mode: "insensitive" } },
+      { summary: { contains: search, mode: "insensitive" } },
+    ];
+    appliedFilters.search = search;
+  }
+
+  if (q.categoryId !== undefined) {
+    const categoryId = parsePositiveInt(q.categoryId);
+    if (categoryId === null) {
+      invalidQuery(res, "categoryId", "categoryId must be a positive integer.");
+      return;
+    }
+    where.categoryId = categoryId;
+    appliedFilters.categoryId = categoryId;
+  }
+
+  if (q.relatedSystemId !== undefined) {
+    const relatedSystemId = parsePositiveInt(q.relatedSystemId);
+    if (relatedSystemId === null) {
+      invalidQuery(res, "relatedSystemId", "relatedSystemId must be a positive integer.");
+      return;
+    }
+    where.relatedSystemId = relatedSystemId;
+    appliedFilters.relatedSystemId = relatedSystemId;
+  }
+
+  if (q.requestedPriority !== undefined) {
+    const requestedPriority = String(q.requestedPriority);
+    if (!(PRIORITIES as readonly string[]).includes(requestedPriority)) {
+      invalidQuery(res, "requestedPriority", "requestedPriority must be one of LOW, MEDIUM, HIGH, URGENT.");
+      return;
+    }
+    where.requestedPriority = requestedPriority as Prisma.TicketWhereInput["requestedPriority"];
+    appliedFilters.requestedPriority = requestedPriority;
+  }
+
+  if (q.status !== undefined) {
+    const status = String(q.status);
+    if (!(STATUSES as readonly string[]).includes(status)) {
+      invalidQuery(res, "status", "status must be NEW.");
+      return;
+    }
+    where.currentStatus = status as Prisma.TicketWhereInput["currentStatus"];
+    appliedFilters.status = status;
+  }
+
+  try {
+    const totalItems = await prisma.ticket.count({ where });
+    const totalPages = Math.max(1, Math.ceil(totalItems / pageSize));
+
+    // page — defaults to 1; anything beyond the real range is 400, not an
+    // empty page (BR-13, AC-13)
+    let page = 1;
+    if (q.page !== undefined) {
+      const n = parsePositiveInt(q.page);
+      if (n === null) {
+        invalidQuery(res, "page", "page must be a positive integer.");
+        return;
+      }
+      if (n > totalPages) {
+        invalidQuery(res, "page", `page must be between 1 and ${totalPages}.`);
+        return;
+      }
+      page = n;
+    }
+
+    const tickets = await prisma.ticket.findMany({
+      where,
+      // Secondary sort by id:desc always applied (BR-12) so pagination stays
+      // stable when the primary sort key has ties.
+      orderBy: [{ [sortField]: sortDir } as Prisma.TicketOrderByWithRelationInput, { id: "desc" }],
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+      include: { category: { select: { name: true } } },
+    });
+
+    res.status(200).json({
+      data: tickets.map((t) => ({
+        id: t.id,
+        ticketNumber: t.ticketNumber,
+        summary: t.summary,
+        categoryId: t.categoryId,
+        categoryName: t.category.name,
+        requestedPriority: t.requestedPriority,
+        currentStatus: t.currentStatus,
+        createdAt: t.createdAt,
+        updatedAt: t.updatedAt,
+      })),
+      meta: {
+        page,
+        pageSize,
+        totalItems,
+        totalPages,
+        sort: `${sortField}:${sortDir}`,
+        appliedFilters,
+      },
+    });
+  } catch {
+    res.status(500).json({ error: "INTERNAL_ERROR", message: "Something went wrong. Please try again." });
+  }
+});

--- a/server/tests/lab-02/my-tickets.api.test.ts
+++ b/server/tests/lab-02/my-tickets.api.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import request from "supertest";
+import { app } from "../../src/app.js";
+import { getPrisma } from "../../src/prisma.js";
+import { seedAll } from "../../prisma/seed.js";
+
+// api-spec.md §5, specification.md BR-09, BR-11..BR-13, AC-10..AC-14.
+describe("GET /api/tickets", () => {
+  let requesterA: number;
+  let requesterB: number;
+  let categoryId: number;
+  let relatedSystemId: number;
+
+  async function makeTicket(
+    requesterId: number,
+    overrides: Partial<{ summary: string; ticketNumber: string; createdAt: Date }> = {},
+  ) {
+    return getPrisma().ticket.create({
+      data: {
+        ticketNumber: overrides.ticketNumber ?? `TKT-TEST-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        requesterId,
+        categoryId,
+        relatedSystemId,
+        summary: overrides.summary ?? "Test ticket for My Tickets API",
+        description: "A".repeat(30),
+        requestedPriority: "MEDIUM",
+        ...(overrides.createdAt ? { createdAt: overrides.createdAt } : {}),
+      },
+    });
+  }
+
+  beforeAll(async () => {
+    await seedAll();
+    const prisma = getPrisma();
+    const requesters = await prisma.requesterUser.findMany({ where: { isActive: true }, take: 2 });
+    requesterA = requesters[0].id;
+    requesterB = requesters[1].id;
+    const category = await prisma.category.findFirstOrThrow({ where: { isActive: true } });
+    const relatedSystem = await prisma.relatedSystem.findFirstOrThrow({ where: { isActive: true } });
+    categoryId = category.id;
+    relatedSystemId = relatedSystem.id;
+  });
+
+  // API-07
+  it("scopes results to the requesting Requester only (BR-09)", async () => {
+    const uniqueSummary = `Requester A only ${Date.now()}`;
+    await makeTicket(requesterA, { summary: uniqueSummary });
+
+    const resA = await request(app)
+      .get("/api/tickets?pageSize=50")
+      .set("X-Dev-Requester-Id", String(requesterA));
+    expect(resA.body.data.some((t: { summary: string }) => t.summary === uniqueSummary)).toBe(true);
+
+    const resB = await request(app)
+      .get("/api/tickets?pageSize=50")
+      .set("X-Dev-Requester-Id", String(requesterB));
+    expect(resB.body.data.some((t: { summary: string }) => t.summary === uniqueSummary)).toBe(false);
+  });
+
+  // API-08
+  it("search matches both ticketNumber and summary (BR-11)", async () => {
+    const marker = `Marker${Date.now()}`;
+    const ticket = await makeTicket(requesterA, { summary: `Something with ${marker} inside` });
+
+    const bySummary = await request(app)
+      .get(`/api/tickets?search=${marker}`)
+      .set("X-Dev-Requester-Id", String(requesterA));
+    expect(bySummary.body.data.some((t: { id: number }) => t.id === ticket.id)).toBe(true);
+
+    const byNumber = await request(app)
+      .get(`/api/tickets?search=${ticket.ticketNumber}`)
+      .set("X-Dev-Requester-Id", String(requesterA));
+    expect(byNumber.body.data.some((t: { id: number }) => t.id === ticket.id)).toBe(true);
+
+    const noMatch = await request(app)
+      .get("/api/tickets?search=zzz-definitely-no-match-zzz")
+      .set("X-Dev-Requester-Id", String(requesterA));
+    expect(noMatch.body.data).toHaveLength(0);
+  });
+
+  // API-09
+  it("keeps paginated order stable via the secondary id:desc sort when createdAt ties (BR-12)", async () => {
+    const tieTime = new Date("2026-01-01T00:00:00.000Z");
+    await makeTicket(requesterA, { createdAt: tieTime });
+    await makeTicket(requesterA, { createdAt: tieTime });
+
+    const res1 = await request(app)
+      .get("/api/tickets?sort=createdAt:desc&pageSize=50")
+      .set("X-Dev-Requester-Id", String(requesterA));
+    const res2 = await request(app)
+      .get("/api/tickets?sort=createdAt:desc&pageSize=50")
+      .set("X-Dev-Requester-Id", String(requesterA));
+
+    expect(res1.body.data.map((t: { id: number }) => t.id)).toEqual(
+      res2.body.data.map((t: { id: number }) => t.id),
+    );
+  });
+
+  // API-10
+  it("rejects an invalid pageSize and an out-of-range page with 400, naming the field (BR-13)", async () => {
+    const badPageSize = await request(app)
+      .get("/api/tickets?pageSize=7")
+      .set("X-Dev-Requester-Id", String(requesterA));
+    expect(badPageSize.status).toBe(400);
+    expect(badPageSize.body.fieldErrors).toHaveProperty("pageSize");
+
+    const badPage = await request(app)
+      .get("/api/tickets?page=999")
+      .set("X-Dev-Requester-Id", String(requesterA));
+    expect(badPage.status).toBe(400);
+    expect(badPage.body.fieldErrors).toHaveProperty("page");
+  });
+
+  // API-11
+  it("distinguishes the empty-account state from the no-results-for-filter state (AC-11/AC-12)", async () => {
+    const zeroTicketRequester = await getPrisma().requesterUser.create({
+      data: {
+        fullName: `Zero Ticket Requester ${Date.now()}`,
+        email: `zero-ticket-${Date.now()}@example.dev`,
+        isActive: true,
+      },
+    });
+
+    const empty = await request(app)
+      .get("/api/tickets")
+      .set("X-Dev-Requester-Id", String(zeroTicketRequester.id));
+    expect(empty.body.data).toHaveLength(0);
+    expect(empty.body.meta.appliedFilters.search).toBeNull();
+
+    const noResults = await request(app)
+      .get("/api/tickets?search=definitely-not-a-real-match-xyz")
+      .set("X-Dev-Requester-Id", String(requesterA));
+    expect(noResults.body.data).toHaveLength(0);
+    expect(noResults.body.meta.appliedFilters.search).toBe("definitely-not-a-real-match-xyz");
+  });
+
+  it("rejects an inactive Requester with 403", async () => {
+    const inactive = await getPrisma().requesterUser.findFirstOrThrow({ where: { isActive: false } });
+    const res = await request(app).get("/api/tickets").set("X-Dev-Requester-Id", String(inactive.id));
+    expect(res.status).toBe(403);
+  });
+
+  it("defaults to createdAt:desc sort and pageSize 10 when no query params are given", async () => {
+    const res = await request(app).get("/api/tickets").set("X-Dev-Requester-Id", String(requesterA));
+    expect(res.status).toBe(200);
+    expect(res.body.meta.sort).toBe("createdAt:desc");
+    expect(res.body.meta.pageSize).toBe(10);
+  });
+});


### PR DESCRIPTION
## Summary
Implements `GET /api/tickets` per `api-spec.md` §5: search, filters, sort, and pagination, always scoped to the requesting Requester.

## Details
- Ownership scoping (BR-09): results are always filtered by `requesterId`, never client-overridable
- Search (BR-11): case-insensitive substring match on both `ticketNumber` and `summary`
- Sort (BR-12): `createdAt|updatedAt|ticketNumber|requestedPriority`, default `createdAt:desc`, always with a secondary `id:desc` tiebreak so pagination stays stable across ties
- Strict validation (BR-13): invalid `pageSize`/`page`/`sort`/filter values return `400` naming the field, never silently clamped
- `meta.appliedFilters` lets the client distinguish the empty-account state (AC-12) from the no-results-for-filter state (AC-11)

## Test evidence
`cd server && npm test` — 8 files, 35 tests passing (2 Lab 1 + 33 Lab 2). API-07..API-11 now Pass in tests.md.

Resolves #28

Note: this PR targets `lab2-staging`, not the default branch, so the keyword above shows as a mention only. Link it to Issue 28 manually via the Development panel per the TokTickIT GitHub Workflow Guide.