### PR TITLE
Fix: disable server test file parallelism to prevent cross-file DB races

### DIFF
--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -5,5 +5,12 @@ export default defineConfig({
     environment: "node",
     include: ["tests/**/*.test.ts"],
     setupFiles: ["./tests/setup.ts"],
+    // Every test file shares one real Postgres test database (no per-file
+    // transaction/schema isolation), so running files in parallel lets them
+    // race on the same rows — e.g. one file's ticket insert lands between
+    // another file's two "identical" queries, flaking a pagination-order
+    // assertion. Sequential files trade some speed for determinism, which
+    // matters more for a suite that must pass reliably from `main`.
+    fileParallelism: false,
   },
 });


### PR DESCRIPTION
## Summary
Found while starting Issue 29: `server/tests/lab-02/my-tickets.api.test.ts`'s pagination-order-stability assertion (API-09) was intermittently failing. Root cause: every server test file shares one real Postgres test database with no per-file transaction or schema isolation, and Vitest runs test files in parallel by default — so one file's concurrent `ticket.create` could land between two otherwise-identical requests in another file, changing which rows/order came back.

## Fix
Added `fileParallelism: false` to `server/vitest.config.ts`. Test files now run sequentially against the shared test DB instead of racing on it.

## Verification
Ran `cd server && npm test` 4 times in a row: 8 files / 35 tests passing every time (previously intermittent). Suite runtime went from ~1.7s to ~4.3s — an acceptable trade for a suite that must pass reliably from `main`.

## Note
Small, targeted config fix — no dedicated Issue, per the TokTickIT GitHub Workflow Guide's allowance for very small edits. Link it to nothing in the Development panel; just review and merge.