### PR TITLE
Issue 30: Requester Ticket Detail (API + UI)

### DIFF
--- a/client/src/api/ticketDetail.ts
+++ b/client/src/api/ticketDetail.ts
@@ -1,0 +1,48 @@
+const API_URL = import.meta.env.VITE_API_URL ?? "http://localhost:3000";
+
+export interface TicketDetailAttachment {
+  id: number;
+  originalFilename: string;
+  mimeType: string;
+  sizeBytes: number;
+  uploadedAt: string;
+  removedAt: string | null;
+  removalReason: string | null;
+}
+
+export interface TicketDetail {
+  id: number;
+  ticketNumber: string;
+  requesterId: number;
+  requesterName: string;
+  summary: string;
+  description: string;
+  categoryId: number;
+  categoryName: string;
+  relatedSystemId: number;
+  relatedSystemName: string;
+  requestedPriority: "LOW" | "MEDIUM" | "HIGH" | "URGENT";
+  itPriority: string | null;
+  currentStatus: "NEW";
+  createdAt: string;
+  updatedAt: string;
+  attachments: TicketDetailAttachment[];
+}
+
+// Thrown on 404 so the page can show "Ticket not found" without
+// distinguishing "doesn't exist" from "not yours" (BR-10/BR-28).
+export class TicketNotFoundError extends Error {}
+
+// Issue 30 — GET /api/tickets/:id (api-spec.md §6).
+export async function fetchTicketDetail(requesterId: number, ticketId: string): Promise<TicketDetail> {
+  const res = await fetch(`${API_URL}/api/tickets/${ticketId}`, {
+    headers: { "X-Dev-Requester-Id": String(requesterId) },
+  });
+  if (res.status === 404) {
+    throw new TicketNotFoundError("Ticket not found.");
+  }
+  if (!res.ok) {
+    throw new Error("Unable to load this ticket. Please try again.");
+  }
+  return res.json();
+}

--- a/client/src/pages/TicketDetailPage.tsx
+++ b/client/src/pages/TicketDetailPage.tsx
@@ -1,10 +1,147 @@
-// Placeholder route target for Issue 23's router skeleton.
-// Real implementation is Issue 30 — see docs/lab-02/ui-spec.md §8.
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { useRequester } from "../context/RequesterContext.js";
+import { fetchTicketDetail, TicketDetail, TicketNotFoundError } from "../api/ticketDetail.js";
+import { Spinner } from "../components/ui/Spinner.js";
+import { Alert } from "../components/ui/Alert.js";
+import { PriorityBadge, StatusBadge, AttachmentStateBadge } from "../components/ui/Badge.js";
+
+type PageState = "loading" | "loaded" | "not-found" | "error";
+
+function formatDateTime(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" });
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+// Issue 30 — Requester Ticket Detail (ui-spec.md §8): read-only header
+// block, clearly separated from the Attachments section. Attachment
+// add/download/soft-remove actions ship in Issue 31 — this issue only
+// displays existing attachment metadata (BR-23: metadata always visible,
+// active vs removed distinguished by badge, not by hiding removed rows).
 export function TicketDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const { requester } = useRequester();
+  const [state, setState] = useState<PageState>("loading");
+  const [ticket, setTicket] = useState<TicketDetail | null>(null);
+
+  useEffect(() => {
+    if (!requester || !id) return;
+    let cancelled = false;
+    setState("loading");
+    fetchTicketDetail(requester.id, id)
+      .then((detail) => {
+        if (cancelled) return;
+        setTicket(detail);
+        setState("loaded");
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setState(err instanceof TicketNotFoundError ? "not-found" : "error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [requester?.id, id]);
+
+  if (state === "loading") {
+    return <Spinner label="Loading ticket…" />;
+  }
+
+  if (state === "not-found") {
+    // BR-10/BR-28 — identical whether the ticket never existed or belongs
+    // to another Requester; never reveal which.
+    return (
+      <div>
+        <Alert tone="error">Ticket not found.</Alert>
+        <p style={{ marginTop: "var(--zen-space-3)" }}>
+          <Link to="/tickets">← Back to My Tickets</Link>
+        </p>
+      </div>
+    );
+  }
+
+  if (state === "error" || !ticket) {
+    return <Alert tone="error">Unable to load this ticket. Please try again.</Alert>;
+  }
+
   return (
     <div>
-      <h1 style={{ fontSize: "var(--zen-fs-h1)" }}>Ticket Detail</h1>
-      <p>Implemented in Issue 30.</p>
+      <p style={{ marginBottom: "var(--zen-space-3)" }}>
+        <Link to="/tickets">← Back to My Tickets</Link>
+      </p>
+
+      <h1 style={{ fontSize: "var(--zen-fs-h1)", marginTop: 0 }}>{ticket.ticketNumber}</h1>
+
+      <div className="zen-detail-header">
+        <div className="zen-detail-field">
+          <span className="zen-detail-label">Requester</span>
+          <span className="zen-detail-value">{ticket.requesterName}</span>
+        </div>
+        <div className="zen-detail-field">
+          <span className="zen-detail-label">Category</span>
+          <span className="zen-detail-value">{ticket.categoryName}</span>
+        </div>
+        <div className="zen-detail-field">
+          <span className="zen-detail-label">Related System</span>
+          <span className="zen-detail-value">{ticket.relatedSystemName}</span>
+        </div>
+        <div className="zen-detail-field">
+          <span className="zen-detail-label">Requested Priority</span>
+          <span className="zen-detail-value">
+            <PriorityBadge priority={ticket.requestedPriority} />
+          </span>
+        </div>
+        <div className="zen-detail-field">
+          <span className="zen-detail-label">Current Status</span>
+          <span className="zen-detail-value">
+            <StatusBadge status={ticket.currentStatus} />
+          </span>
+        </div>
+        <div className="zen-detail-field">
+          <span className="zen-detail-label">Last Updated</span>
+          <span className="zen-detail-value">{formatDateTime(ticket.updatedAt)}</span>
+        </div>
+        <div className="zen-detail-field" style={{ gridColumn: "1 / -1" }}>
+          <span className="zen-detail-label">Summary</span>
+          <span className="zen-detail-value">{ticket.summary}</span>
+        </div>
+        <div className="zen-detail-field" style={{ gridColumn: "1 / -1" }}>
+          <span className="zen-detail-label">Description</span>
+          <span className="zen-detail-value" style={{ whiteSpace: "pre-wrap" }}>
+            {ticket.description}
+          </span>
+        </div>
+      </div>
+
+      <hr className="zen-detail-divider" />
+
+      <h2 style={{ fontSize: "var(--zen-fs-h2)" }}>Attachments</h2>
+
+      {ticket.attachments.length === 0 ? (
+        <p style={{ color: "var(--zen-text-muted)" }}>No attachments on this ticket yet.</p>
+      ) : (
+        <div>
+          {ticket.attachments.map((a) => (
+            <div key={a.id} className="zen-attachment-row">
+              <span className="zen-attachment-name" title={a.originalFilename}>
+                {a.originalFilename}
+              </span>
+              <AttachmentStateBadge removed={a.removedAt !== null} />
+              <span className="zen-attachment-meta">
+                {formatSize(a.sizeBytes)} · uploaded {formatDateTime(a.uploadedAt)}
+              </span>
+              {a.removedAt && a.removalReason && (
+                <span className="zen-attachment-meta">Removed: {a.removalReason}</span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/client/src/styles/zen-green.css
+++ b/client/src/styles/zen-green.css
@@ -424,3 +424,74 @@ textarea.zen-field-control {
     display: block;
   }
 }
+
+/* --------------------------------------------------------- Ticket Detail */
+/* Header block and Attachments are visually separated (ui-spec.md §8) so
+   later labs' Comments/Notes/Actions Taken have an unambiguous place to go
+   without being confused for read-only ticket data. */
+
+.zen-detail-header {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--zen-space-3);
+  background: var(--zen-surface);
+  border: 1px solid var(--zen-border);
+  border-radius: 8px;
+  padding: var(--zen-space-4);
+}
+
+@media (min-width: 768px) {
+  .zen-detail-header {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.zen-detail-field {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.zen-detail-label {
+  font-size: var(--zen-fs-label);
+  font-weight: 600;
+  color: var(--zen-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.zen-detail-value {
+  font-size: var(--zen-fs-body);
+}
+
+.zen-detail-divider {
+  border: none;
+  border-top: 1px solid var(--zen-border);
+  margin: var(--zen-space-5) 0;
+}
+
+.zen-attachment-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--zen-space-3);
+  padding: var(--zen-space-3) 0;
+  border-bottom: 1px solid var(--zen-border);
+}
+
+.zen-attachment-row:last-child {
+  border-bottom: none;
+}
+
+.zen-attachment-name {
+  font-weight: 600;
+  flex: 1 1 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.zen-attachment-meta {
+  color: var(--zen-text-muted);
+  font-size: var(--zen-fs-caption);
+}

--- a/client/tests/lab-02/RequesterTicketDetail.test.tsx
+++ b/client/tests/lab-02/RequesterTicketDetail.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { RequesterProvider } from "../../src/context/RequesterContext.js";
+import { TicketDetailPage } from "../../src/pages/TicketDetailPage.js";
+
+function renderAt(path: string, requester = { id: 1, fullName: "Aran Suksawat" }) {
+  sessionStorage.setItem("toktickit:lab2:selectedRequester", JSON.stringify(requester));
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <RequesterProvider>
+        <Routes>
+          <Route path="/tickets/:id" element={<TicketDetailPage />} />
+        </Routes>
+      </RequesterProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("Requester Ticket Detail screen", () => {
+  afterEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("shows the owned ticket's header fields and attachments", async () => {
+    renderAt("/tickets/1");
+    expect(await screen.findByRole("heading", { name: "TKT-2026-000001" })).toBeInTheDocument();
+    expect(screen.getByText("Laptop battery drains quickly")).toBeInTheDocument();
+    expect(screen.getByText("battery-log.pdf")).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+  });
+
+  // UI-12
+  it("shows 'Ticket not found' with a link back for another Requester's ticket", async () => {
+    renderAt("/tickets/1", { id: 2, fullName: "Buppha Ratanakorn" });
+    expect(await screen.findByText("Ticket not found.")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /back to my tickets/i })).toHaveAttribute("href", "/tickets");
+  });
+
+  it("shows the identical 'Ticket not found' message for a nonexistent ticket id", async () => {
+    renderAt("/tickets/999999");
+    expect(await screen.findByText("Ticket not found.")).toBeInTheDocument();
+  });
+});

--- a/client/tests/msw/handlers.ts
+++ b/client/tests/msw/handlers.ts
@@ -90,4 +90,42 @@ export const handlers = [
       },
     });
   }),
+
+  // Issue 30 — GET /api/tickets/:id. id 1 exists and is owned by requester
+  // "1"; anything else 404s, matching the real endpoint's not-found-vs-
+  // not-owned behavior (BR-10/BR-28).
+  http.get(`${API_URL}/api/tickets/:id`, ({ params, request }) => {
+    const requesterId = request.headers.get("X-Dev-Requester-Id");
+    if (params.id !== "1" || requesterId !== "1") {
+      return HttpResponse.json({ error: "TICKET_NOT_FOUND", message: "Ticket not found." }, { status: 404 });
+    }
+    return HttpResponse.json({
+      id: 1,
+      ticketNumber: "TKT-2026-000001",
+      requesterId: 1,
+      requesterName: "Aran Suksawat",
+      summary: "Laptop battery drains quickly",
+      description: "The battery on my corporate laptop drains quickly.",
+      categoryId: 1,
+      categoryName: "Hardware",
+      relatedSystemId: 1,
+      relatedSystemName: "Corporate Laptop",
+      requestedPriority: "MEDIUM",
+      itPriority: null,
+      currentStatus: "NEW",
+      createdAt: "2026-08-24T10:00:00.000Z",
+      updatedAt: "2026-08-24T10:00:00.000Z",
+      attachments: [
+        {
+          id: 1,
+          originalFilename: "battery-log.pdf",
+          mimeType: "application/pdf",
+          sizeBytes: 20480,
+          uploadedAt: "2026-08-24T10:05:00.000Z",
+          removedAt: null,
+          removalReason: null,
+        },
+      ],
+    });
+  }),
 ];

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -33,8 +33,8 @@ Criterion in `specification.md` §9 maps to at least one row below.
 | API-09 | API | BR-12 | Two tickets with identical `createdAt`, sorted by `createdAt:desc` twice | Row order identical both times (secondary `id:desc` holds) | `server/tests/lab-02/my-tickets.api.test.ts` | **Pass** |
 | API-10 | API | AC-13, BR-13 | `pageSize=7` and `page=999` | Both `400`, naming the invalid parameter | `server/tests/lab-02/my-tickets.api.test.ts` | **Pass** |
 | API-11 | API | AC-11, AC-12 | List with 0 tickets ever vs. 0 tickets matching an active filter | `meta.appliedFilters` distinguishes the two cases correctly | `server/tests/lab-02/my-tickets.api.test.ts` | **Pass** |
-| API-12 | API | AC-03, BR-10 | `GET /api/tickets/:id` for another Requester's ticket | `404`, identical body to a nonexistent id | `server/tests/lab-02/ticket-detail.api.test.ts` | Planned |
-| API-13 | API | FR-05 | `GET /api/tickets/:id` for own ticket | `200`; includes nested `attachments` array | `server/tests/lab-02/ticket-detail.api.test.ts` | Planned |
+| API-12 | API | AC-03, BR-10 | `GET /api/tickets/:id` for another Requester's ticket | `404`, identical body to a nonexistent id | `server/tests/lab-02/ticket-detail.api.test.ts` | **Pass** |
+| API-13 | API | FR-05 | `GET /api/tickets/:id` for own ticket | `200`; includes nested `attachments` array | `server/tests/lab-02/ticket-detail.api.test.ts` | **Pass** |
 | API-14 | API | AC-06, BR-21 | `POST .../attachments` on a ticket that already has 5 active attachments | `409 ATTACHMENT_LIMIT_REACHED`; count stays 5 | `server/tests/lab-02/attachments.api.test.ts` | Planned |
 | API-15 | API | AC-07, BR-20 | Upload a `.exe` renamed to `.png` (mismatched magic bytes/mimetype) | `415`; not saved | `server/tests/lab-02/attachments.api.test.ts` | Planned |
 | API-16 | API | AC-09, BR-22–24 | `DELETE /api/attachments/:id` with a valid reason on an owned, active attachment | `200`; `removedAt` set; active count decreases by 1 | `server/tests/lab-02/attachments.api.test.ts` | Planned |
@@ -55,7 +55,7 @@ Criterion in `specification.md` §9 maps to at least one row below.
 | UI-09 | UI component | AC-11 vs AC-12 | My Tickets: mocked 0-tickets-ever vs. mocked 0-matches-with-filter | Distinct empty-state and no-results copy render for each case | `client/tests/lab-02/MyTickets.test.tsx` | **Pass** |
 | UI-10 | UI component | AC-10 | My Tickets rendered, then Requester context switched | List refetches and old Requester's rows are gone | `client/tests/lab-02/MyTickets.test.tsx` | **Pass** |
 | UI-11 | UI component | §7 (pagination) | Change page-size control | Triggers a refetch with the new `pageSize`; page resets to 1 | `client/tests/lab-02/MyTickets.test.tsx` | **Pass** |
-| UI-12 | UI component | AC-03, BR-10/28 | Ticket Detail, mocked `404` from the API | "Ticket not found." message with a link back to My Tickets | `client/tests/lab-02/RequesterTicketDetail.test.tsx` | Planned |
+| UI-12 | UI component | AC-03, BR-10/28 | Ticket Detail, mocked `404` from the API | "Ticket not found." message with a link back to My Tickets | `client/tests/lab-02/RequesterTicketDetail.test.tsx` | **Pass** |
 | UI-13 | UI component | §8 (attachments list) | Ticket Detail with 1 active + 1 removed attachment mocked | Active row has a working Download button; removed row shows its `removalReason` instead of action buttons | `client/tests/lab-02/AttachmentSection.test.tsx` | Planned |
 | UI-14 | UI component | AC-09 | Click Remove on an active attachment, submit without typing a reason | Client-side validation blocks submission; no DELETE fired | `client/tests/lab-02/AttachmentSection.test.tsx` | Planned |
 | UI-15 | UI component | AC-09 | Remove an attachment with a valid reason, mocked success | Attachment row updates to Removed badge + shows the reason | `client/tests/lab-02/AttachmentSection.test.tsx` | Planned |

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -3,6 +3,7 @@ import cors from "cors";
 import { referenceRouter } from "./routes/reference.js";
 import { ticketsRouter } from "./routes/tickets.js";
 import { myTicketsRouter } from "./routes/myTickets.js";
+import { ticketDetailRouter } from "./routes/ticketDetail.js";
 
 // The Express app is exported separately from app.listen() (see index.ts) so
 // Supertest can import `app` without opening a port. Do not merge these files.
@@ -29,5 +30,8 @@ app.use(ticketsRouter);
 
 // Issue 28 — GET /api/tickets (paginated, owned list). See routes/myTickets.ts.
 app.use(myTicketsRouter);
+
+// Issue 30 — GET /api/tickets/:id (owned detail). See routes/ticketDetail.ts.
+app.use(ticketDetailRouter);
 
 export default app;

--- a/server/src/routes/ticketDetail.ts
+++ b/server/src/routes/ticketDetail.ts
@@ -1,0 +1,64 @@
+import { Router, Request, Response } from "express";
+import { getPrisma } from "../prisma.js";
+import { requesterAuth } from "../middleware/requesterAuth.js";
+
+// Issue 30 — GET /api/tickets/:id (api-spec.md §6). BR-10/BR-28: a ticket
+// that doesn't exist and a ticket that exists but belongs to someone else
+// return the identical 404 body, so ownership can never be probed.
+export const ticketDetailRouter = Router();
+
+const NOT_FOUND = { error: "TICKET_NOT_FOUND", message: "Ticket not found." };
+
+ticketDetailRouter.get("/api/tickets/:id", requesterAuth, async (req: Request, res: Response) => {
+  const id = Number(req.params.id);
+  if (!Number.isInteger(id) || id <= 0) {
+    res.status(404).json(NOT_FOUND);
+    return;
+  }
+
+  try {
+    const ticket = await getPrisma().ticket.findFirst({
+      where: { id, requesterId: req.requester!.id },
+      include: {
+        requester: { select: { fullName: true } },
+        category: { select: { name: true } },
+        relatedSystem: { select: { name: true } },
+        attachments: { orderBy: { uploadedAt: "asc" } },
+      },
+    });
+
+    if (!ticket) {
+      res.status(404).json(NOT_FOUND);
+      return;
+    }
+
+    res.status(200).json({
+      id: ticket.id,
+      ticketNumber: ticket.ticketNumber,
+      requesterId: ticket.requesterId,
+      requesterName: ticket.requester.fullName,
+      summary: ticket.summary,
+      description: ticket.description,
+      categoryId: ticket.categoryId,
+      categoryName: ticket.category.name,
+      relatedSystemId: ticket.relatedSystemId,
+      relatedSystemName: ticket.relatedSystem.name,
+      requestedPriority: ticket.requestedPriority,
+      itPriority: ticket.itPriority,
+      currentStatus: ticket.currentStatus,
+      createdAt: ticket.createdAt,
+      updatedAt: ticket.updatedAt,
+      attachments: ticket.attachments.map((a) => ({
+        id: a.id,
+        originalFilename: a.originalFilename,
+        mimeType: a.mimeType,
+        sizeBytes: a.sizeBytes,
+        uploadedAt: a.uploadedAt,
+        removedAt: a.removedAt,
+        removalReason: a.removalReason,
+      })),
+    });
+  } catch {
+    res.status(500).json({ error: "INTERNAL_ERROR", message: "Something went wrong. Please try again." });
+  }
+});

--- a/server/tests/lab-02/ticket-detail.api.test.ts
+++ b/server/tests/lab-02/ticket-detail.api.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import request from "supertest";
+import { app } from "../../src/app.js";
+import { getPrisma } from "../../src/prisma.js";
+import { seedAll } from "../../prisma/seed.js";
+
+// api-spec.md §6, specification.md BR-10, BR-28, FR-05, AC-03.
+describe("GET /api/tickets/:id", () => {
+  let requesterA: number;
+  let requesterB: number;
+  let ownedTicketId: number;
+
+  beforeAll(async () => {
+    await seedAll();
+    const prisma = getPrisma();
+    const requesters = await prisma.requesterUser.findMany({ where: { isActive: true }, take: 2 });
+    requesterA = requesters[0].id;
+    requesterB = requesters[1].id;
+    const category = await prisma.category.findFirstOrThrow({ where: { isActive: true } });
+    const relatedSystem = await prisma.relatedSystem.findFirstOrThrow({ where: { isActive: true } });
+
+    const ticket = await prisma.ticket.create({
+      data: {
+        ticketNumber: `TKT-TEST-DETAIL-${Date.now()}`,
+        requesterId: requesterA,
+        categoryId: category.id,
+        relatedSystemId: relatedSystem.id,
+        summary: "Detail-endpoint test ticket",
+        description: "A".repeat(30),
+        requestedPriority: "MEDIUM",
+      },
+    });
+    ownedTicketId = ticket.id;
+
+    await prisma.attachment.create({
+      data: {
+        ticketId: ownedTicketId,
+        originalFilename: "evidence.pdf",
+        storedFilename: `${Date.now()}-evidence.pdf`,
+        mimeType: "application/pdf",
+        sizeBytes: 12345,
+        uploadedById: requesterA,
+      },
+    });
+  });
+
+  // API-13
+  it("returns full detail, including nested attachments, for an owned Ticket", async () => {
+    const res = await request(app)
+      .get(`/api/tickets/${ownedTicketId}`)
+      .set("X-Dev-Requester-Id", String(requesterA));
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(ownedTicketId);
+    expect(res.body.requesterId).toBe(requesterA);
+    expect(res.body.attachments).toHaveLength(1);
+    expect(res.body.attachments[0].originalFilename).toBe("evidence.pdf");
+    expect(res.body.attachments[0].removedAt).toBeNull();
+  });
+
+  // API-12
+  it("returns 404 for another Requester's Ticket, identical to a nonexistent id", async () => {
+    const forOther = await request(app)
+      .get(`/api/tickets/${ownedTicketId}`)
+      .set("X-Dev-Requester-Id", String(requesterB));
+    expect(forOther.status).toBe(404);
+    expect(forOther.body).toEqual({ error: "TICKET_NOT_FOUND", message: "Ticket not found." });
+
+    const nonexistent = await request(app)
+      .get("/api/tickets/999999999")
+      .set("X-Dev-Requester-Id", String(requesterB));
+    expect(nonexistent.status).toBe(404);
+    expect(nonexistent.body).toEqual(forOther.body);
+  });
+
+  it("returns 404 for a non-numeric id rather than throwing", async () => {
+    const res = await request(app)
+      .get("/api/tickets/not-a-number")
+      .set("X-Dev-Requester-Id", String(requesterA));
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects an inactive Requester with 403", async () => {
+    const inactive = await getPrisma().requesterUser.findFirstOrThrow({ where: { isActive: false } });
+    const res = await request(app)
+      .get(`/api/tickets/${ownedTicketId}`)
+      .set("X-Dev-Requester-Id", String(inactive.id));
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary
Implements `GET /api/tickets/:id` per `api-spec.md` §6 and the Requester Ticket Detail screen per `ui-spec.md` §8, replacing the Issue 23 placeholder. Read-only header, read-only Attachments list — add/download/soft-remove actions land in Issue 31.

## Details
- BR-10/BR-28: a ticket that doesn't exist and one that exists but isn't owned by the caller return the identical `404` body, so ownership can never be probed from the outside
- BR-23: attachment metadata (filename, size, uploaded date, Active/Removed badge, removal reason) is always shown, active or removed
- Header block and Attachments section are visually separated by a divider, so later labs' Comments/Notes/Actions Taken have an unambiguous place to go

## Test evidence
- `cd server && npm test` — 9 files, 39 tests passing (2 Lab 1 + 37 Lab 2)
- `cd client && npm test` — 6 files, 28 tests passing (3 Lab 1 + 25 Lab 2)
- API-12/13 and UI-12 now Pass in tests.md. `npm run build` clean.

Resolves #30

Note: this PR targets `lab2-staging`, not the default branch, so the keyword above shows as a mention only. Link it to Issue 30 manually via the Development panel per the TokTickIT GitHub Workflow Guide.