### PR TITLE
docs: record PR #55-57 in reviewer.md and generalise the test-run provenance

### DIFF
--- a/docs/lab-02/reviewer.md
+++ b/docs/lab-02/reviewer.md
@@ -154,6 +154,46 @@ lab2-staging right before opening this, not from an older commit?"
 the exact output in the description. Nothing cached from earlier in the sprint."
 **@book6349:** "Approved, merging into main." — Approved.
 
+## Documentation fixes after the release (PR #55 onward)
+
+These came out of an external review of the draft submission report, which found places where these
+documents contradicted each other or claimed more than was true. Each went feature branch to
+`lab2-staging` to `main`, reviewed and approved before merge.
+
+| PR | Base <- Head | Purpose | Reviewer verdict |
+|----|--------------|---------|-------------------|
+| [#55](https://github.com/Punge089/toktickit/pull/55) | lab2-staging <- fix/lab2-doc-consistency | Fix internal contradictions, record workflow exceptions honestly | Commented, replied, Approved |
+| [#56](https://github.com/Punge089/toktickit/pull/56) | main <- lab2-staging | Release carrying #55 | Commented, replied, Approved |
+| [#57](https://github.com/Punge089/toktickit/pull/57) | lab2-staging <- fix/br23-detail-fields | Implement BR-23 metadata, Ticket Date, token link colour; 104 to 108 tests | Commented, replied, Approved |
+
+### PR #55 - Documentation consistency
+**@book6349:** "You unticked the colour checklist item and added a known-deviations table instead of just
+fixing the code. Doesn't that lose marks? Feels like we're advertising our own weak spots in the spec."
+**Me:** "Thought about that too. But the links really are blue and it's visible in every screenshot we're
+submitting, so leaving it ticked is a false claim in the report, which is worse than a CSS bug."
+**@book6349:** "Very good staging." - Approved.
+
+*(That answer stopped being the right call once we checked BR-23, which is what PR #57 fixed.)*
+
+### PR #56 - Release carrying #55 into main
+**@book6349:** "Just the release for #55, nothing new in it?"
+**Me:** "Right, same two commits, no extra changes. Going staging to main like #49/#51/#53 did."
+**@book6349:** "Oh I see, merging." - Approved.
+
+### PR #57 - Implement BR-23, Ticket Date and the token link colour
+**@book6349:** "The suite has been green at 104 this whole time. How did BR-23 go missing without
+anything failing?"
+**Me:** "Because nothing actually tested BR-23. AC-08 only asks that a removed row has no Download
+button, which we did correctly. It only turned up by reading the screenshots against the spec we wrote
+ourselves. UI-16 and UI-17 now assert the metadata directly so it can't slip again."
+**@book6349:** "Makes sense, and good that you added tests rather than just fixing the display." -
+Approved.
+
+**A note on the last two PRs.** This file cannot list the pull request that carries its own latest
+version, nor that PR's release. Those are the final two entries in the repository's
+[pull request list](https://github.com/Punge089/toktickit/pulls?q=is%3Apr+is%3Amerged), where their
+review and approval status can be checked directly.
+
 ## Pull Requests I reviewed for my partner
 
 Reviewed all ten of @book6349's Lab 2 Issue PRs, plus their release PR, on their own individual-sprint

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -128,8 +128,9 @@ npx playwright test
 
 ## 6. Final Results
 
-Run on the `fix/br23-detail-fields` branch on 2026-08-29, after the BR-23 and ui-spec fixes described in
-`ui-spec.md` §11, using the commands in §5. What each suite actually runs against:
+Run on 2026-08-29 after the BR-23 and ui-spec fixes described in `ui-spec.md` §11, using the commands in
+§5. The same three commands were re-run from `main` once those fixes were released there, with identical
+results. What each suite actually runs against:
 
 - **server** - the real PostgreSQL test database (`server/.env.test`); no mocking.
 - **client** - jsdom, with the network mocked via `msw` per §1. These are component and style tests and


### PR DESCRIPTION
Last documentation gap from the external review. Docs only, no code, so the 108-test result is unchanged.

## reviewer.md

The file stopped at #54, while the report's cover page cited #56 as the release that carried the fixes to main. That inconsistency is closed here: #55, #56 and #57 are now listed with their real review exchanges, pulled from the GitHub API rather than rewritten from memory.

It also notes the one thing this file structurally cannot do: list the pull request that carries its own latest version, or that PR's release. Those two are the final entries on the repository's PR list, where their approvals can be checked directly. Saying so is better than leaving a silent gap.

Worth keeping in the record: the #55 exchange has me arguing that declaring the four deviations was better than fixing them. That turned out to be wrong once we checked BR-23, which is what #57 fixed. The reply is left as it was written, with a one-line note that it stopped being the right call.

## tests.md

The Final Results block named the branch the suite was first run on. Reworded now that the same run reproduces from `main`.

Requesting review before merge as usual.