### PR TITLE
Lab 2 Release: fix the stale results block in tests.md

### DIFF
--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -144,11 +144,6 @@ client:     Test Files   7 passed (7)    Tests  33 passed (33)
 playwright:            28 passed (28)    (1 flow test + 27 responsive/visual tests)
                                           total: 47 + 33 + 28 = 108
 ```
-server:     Test Files  10 passed (10)   Tests  45 passed (45)
-client:     Test Files   7 passed (7)    Tests  31 passed (31)
-playwright:            28 passed (28)    (1 flow test + 27 responsive/visual tests — see the note under
-                                           §2's E2E rows; 1 + 27 = 28, not 30)
-```
 
 Every Acceptance Criterion in `specification.md` §9 has at least one Pass row above (see the traceability
 matrix in §3). No test is skipped, `.only`'d, or commented out.


### PR DESCRIPTION
Release PR carrying #60 from `lab2-staging` into `main`, on the same path as #49, #51, #53, #56 and #59.

## What this releases

PR #60 removes five orphaned lines from section 6 of `tests.md`. A bad find-and-replace had left the previous results block sitting underneath the new one, so the file reported 108 and then 45/31/28 immediately after, with a stray code fence breaking the markdown on GitHub.

The section now states one total, the correct one:

```
server:     47 passed (47)
client:     33 passed (33)
playwright: 28 passed (28)
total:      108
```

This is the file Part 3 of the submission is graded on, and the report embeds it verbatim, so the contradiction reached the report too.

Documentation only. No code, no test changes, so the 108 result is unaffected.

This is the final pull request for Lab 2.